### PR TITLE
Rename OAuthKit to OAuthClientFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ And then add the dependency to your target:
 ```swift
 import OAuthKit
 
-// Initialize OAuthKit
-let oauthKit = OAuthKit()
+// Initialize OAuth
+let oauthClient = OAuthClientFactory()
 
 // Create an OAuth2 client
 let oauth2Client = oauthKit.oauth2Client(
@@ -93,10 +93,10 @@ print("Access token: \(tokenResponse.accessToken)")
 import OAuthKit
 
 // Initialize OAuthKit
-let oauthKit = OAuthKit()
+let oauthClient = OAuthClientFactory()
 
 // Create Google OAuth provider
-let googleProvider = try await oauthKit.googleProvider(
+let googleProvider = try await oauthClient.googleProvider(
     clientID: "some-client-id",  // From Google Cloud Console
     clientSecret: "some-client-secret", // From Google Cloud Console
     redirectURI: "https://example.com/callback" // Must match Google Console
@@ -138,7 +138,7 @@ For server-to-server authentication without user interaction. There are three wa
 import OAuthKit
 
 // Initialize OAuthKit
-let oauthKit = OAuthKit()
+let oauthKit = OAuthClientFactory()
 
 // Load service account credentials from JSON string
 let serviceAccountJSON = """
@@ -284,7 +284,7 @@ gmailRequest.headers.add(name: "Authorization", value: "Bearer \(delegatedJWT)")
 
 ```swift
 // Initialize OAuthKit
-let oauthKit = OAuthKit()
+let oauthKit = OAuthClientFactory()
 
 // Create Microsoft OAuth provider
 // For multi-tenant applications (works with any Microsoft account):
@@ -345,7 +345,7 @@ print("Graph API data: \(graphData)")
 
 ```swift
 // Initialize OAuthKit
-let oauthKit = OAuthKit()
+let oauthKit = OAuthClientFactory()
 
 // Create an OpenID Connect client with auto-discovery
 let oidcClient = try await oauthKit.openIDConnectClient(
@@ -389,7 +389,7 @@ print("User info: \(userInfo)")
 
 ```swift
 // Initialize OAuthKit
-let oauthKit = OAuthKit()
+let oauthKit = OAuthClientFactory()
 
 // Create an OAuth2 client for client credentials flow
 let oauth2Client = oauthKit.oauth2Client(

--- a/Sources/OAuthKit/OAuthClientFactory.swift
+++ b/Sources/OAuthKit/OAuthClientFactory.swift
@@ -17,7 +17,7 @@ import Foundation
 import Logging
 
 /// Main entry point for OAuthKit functionality
-public struct OAuthKit: Sendable {
+public struct OAuthClientFactory: Sendable {
     /// The HTTP client used for making requests
     internal let httpClient: HTTPClient
 

--- a/Sources/OAuthKit/Providers/AWSCognitoOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/AWSCognitoOAuthProvider.swift
@@ -20,7 +20,7 @@ import NIOFoundationCompat
 /// Provider for AWS Cognito OAuth2/OpenID Connect authentication
 public struct AWSCognitoOAuthProvider {
     /// The OAuthKit instance
-    private let oauthKit: OAuthKit
+    private let oauthKit: OAuthClientFactory
 
     /// An OpenID Connect client configured for AWS Cognito
     private let client: OpenIDConnectClient
@@ -29,7 +29,7 @@ public struct AWSCognitoOAuthProvider {
     /// - Parameter oauthKit: The OAuthKit instance
     /// - Parameter openIDConnectClient: The OpenID Connect client configured for AWS Cognito
     internal init(
-        oauthKit: OAuthKit,
+        oauthKit: OAuthClientFactory,
         openIDConnectClient client: OpenIDConnectClient
     ) {
         self.oauthKit = oauthKit

--- a/Sources/OAuthKit/Providers/AppleOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/AppleOAuthProvider.swift
@@ -39,7 +39,7 @@ public struct AppleOAuthProvider {
     }
 
     /// The OAuthKit instance
-    private let oauthKit: OAuthKit
+    private let oauthKit: OAuthClientFactory
 
     /// An OAuth2 client configured for Apple
     private var client: AppleOAuth2Client
@@ -66,7 +66,7 @@ public struct AppleOAuthProvider {
     /// - Parameter oauthKit: The OAuthKit instance
     /// - Parameter client: An OAuth2 client configured for Apple
     public init(
-        oauthKit: OAuthKit,
+        oauthKit: OAuthClientFactory,
         client: AppleOAuth2Client
     ) {
         self.oauthKit = oauthKit

--- a/Sources/OAuthKit/Providers/FacebookOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/FacebookOAuthProvider.swift
@@ -36,14 +36,14 @@ public struct FacebookOAuthProvider: Sendable {
     }
 
     /// The OAuthKit instance
-    private let oauthKit: OAuthKit
+    private let oauthKit: OAuthClientFactory
 
     /// The OAuth2 client configured for Facebook
     private let client: OAuth2Client
 
     /// Initialize a new Facebook OAuth provider
     /// - Parameter oauthKit: The OAuthKit instance
-    public init(oauthKit: OAuthKit, client: OAuth2Client) {
+    public init(oauthKit: OAuthClientFactory, client: OAuth2Client) {
         self.oauthKit = oauthKit
         self.client = client
     }

--- a/Sources/OAuthKit/Providers/GitHubOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/GitHubOAuthProvider.swift
@@ -35,7 +35,7 @@ public struct GitHubOAuthProvider: Sendable {
     }
 
     /// The OAuthKit instance
-    private let oauthKit: OAuthKit
+    private let oauthKit: OAuthClientFactory
 
     /// An OAuth2 client configured for GitHub
     private let client: OAuth2Client
@@ -44,7 +44,7 @@ public struct GitHubOAuthProvider: Sendable {
     /// - Parameter oauthKit: The OAuthKit instance
     /// - Parameter oauth2Client:  An OAuth2 client configured for GitHub
     public init(
-        oauthKit: OAuthKit,
+        oauthKit: OAuthClientFactory,
         oauth2Client client: OAuth2Client
     ) {
         self.oauthKit = oauthKit

--- a/Sources/OAuthKit/Providers/GoogleOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/GoogleOAuthProvider.swift
@@ -26,7 +26,7 @@ public struct GoogleOAuthProvider: Sendable {
     public static let discoveryURL = "https://accounts.google.com/"
 
     /// The OAuthKit instance
-    private let oauthKit: OAuthKit
+    private let oauthKit: OAuthClientFactory
 
     /// The OpenID Connect client configured for Google
     private let client: OpenIDConnectClient
@@ -40,7 +40,7 @@ public struct GoogleOAuthProvider: Sendable {
     /// - Parameter oauthKit: The OAuthKit instance
     /// - Parameter openIDConnectClient: An OpenID Connect client configured for Google
     public init(
-        oauthKit: OAuthKit,
+        oauthKit: OAuthClientFactory,
         openIDConnectClient client: OpenIDConnectClient
     ) {
         self.oauthKit = oauthKit

--- a/Sources/OAuthKit/Providers/KeyCloakOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/KeyCloakOAuthProvider.swift
@@ -65,7 +65,7 @@ public struct KeyCloakOAuthProvider: Sendable {
     }
 
     /// The OAuthKit instance
-    private let oauthKit: OAuthKit
+    private let oauthKit: OAuthClientFactory
 
     /// KeyCloakBaseURL configured
     private let endpoints: Endpoints
@@ -87,7 +87,7 @@ public struct KeyCloakOAuthProvider: Sendable {
     ///   - endpoints: The Enpoints instance with base url
     ///   - client: An Oauth2Client
     internal init(
-        oauthKit: OAuthKit,
+        oauthKit: OAuthClientFactory,
         endpoints: Endpoints,
         client: OAuth2Client
     ) {

--- a/Sources/OAuthKit/Providers/MicrosoftOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/MicrosoftOAuthProvider.swift
@@ -30,7 +30,7 @@ public struct MicrosoftOAuthProvider: Sendable {
     }
 
     /// The OAuthKit instance
-    private let oauthKit: OAuthKit
+    private let oauthKit: OAuthClientFactory
 
     /// The OpenID Connect client configured for Microsoft
     private let client: OpenIDConnectClient
@@ -38,7 +38,7 @@ public struct MicrosoftOAuthProvider: Sendable {
     /// Initialize a new Microsoft OAuth provider
     /// - Parameter oauthKit: The OAuthKit instance
     /// - Parameter openIDConnectClient: The OpenID Connect client configured for Microsoft
-    internal init(oauthKit: OAuthKit, openIDConnectClient client: OpenIDConnectClient) {
+    internal init(oauthKit: OAuthClientFactory, openIDConnectClient client: OpenIDConnectClient) {
         self.oauthKit = oauthKit
         self.client = client
     }

--- a/Sources/OAuthKit/Providers/OktaOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/OktaOAuthProvider.swift
@@ -20,14 +20,14 @@ import NIOFoundationCompat
 /// Provider for Okta OAuth2/OpenID Connect authentication
 public struct OktaOAuthProvider: Sendable {
     /// The OAuthKit instance
-    private let oauthKit: OAuthKit
+    private let oauthKit: OAuthClientFactory
 
     /// An OpenID Connect client configured for Okta
     private let client: OpenIDConnectClient
 
     /// Initialize a new Okta OAuth provider
     /// - Parameter oauthKit: The OAuthKit instance
-    internal init(oauthKit: OAuthKit, client: OpenIDConnectClient) {
+    internal init(oauthKit: OAuthClientFactory, client: OpenIDConnectClient) {
         self.oauthKit = oauthKit
         self.client = client
     }

--- a/Sources/OAuthKit/Providers/SlackOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/SlackOAuthProvider.swift
@@ -34,7 +34,7 @@ public struct SlackOAuthProvider {
     }
 
     /// The OAuthKit instance
-    private let oauthKit: OAuthKit
+    private let oauthKit: OAuthClientFactory
 
     /// SlackOAuthClient
     private let client: SlackOAuth2Client
@@ -42,7 +42,7 @@ public struct SlackOAuthProvider {
     /// Initialize a new Slack OAuth provider
     /// - Parameter oauthKit: The OAuthKit instance
     /// - Parameter client: A SlackOAuth2Client instance
-    internal init(oauthKit: OAuthKit, client: SlackOAuth2Client) {
+    internal init(oauthKit: OAuthClientFactory, client: SlackOAuth2Client) {
         self.oauthKit = oauthKit
         self.client = client
     }

--- a/Tests/OAuthKitTests/GoogleServiceAccountTests.swift
+++ b/Tests/OAuthKitTests/GoogleServiceAccountTests.swift
@@ -23,12 +23,12 @@ import Testing
 @Suite("Google Service Account Tests")
 struct GoogleServiceAccountTests {
 
-    let oauthKit: OAuthKit
+    let oauthKit: OAuthClientFactory
     let logger: Logger
 
     init() {
         self.logger = Logger(label: "GoogleServiceAccountTests")
-        self.oauthKit = OAuthKit(httpClient: .shared, logger: logger)
+        self.oauthKit = OAuthClientFactory(httpClient: .shared, logger: logger)
     }
 
     @Test("Parse Google Service Account Credentials from JSON")

--- a/Tests/OAuthKitTests/OAuthKitTests.swift
+++ b/Tests/OAuthKitTests/OAuthKitTests.swift
@@ -22,7 +22,7 @@ import Testing
 @Suite("OAuthKit Core Tests")
 struct OAuthKitTests {
     static let logger = Logger(label: "OAuthKitTests")
-    let oauthKit = OAuthKit(httpClient: .shared, logger: logger)
+    let oauthKit = OAuthClientFactory(httpClient: .shared, logger: logger)
 
     @Test("OAuth2 Client Creation")
     func testOAuth2ClientCreation() {

--- a/Tests/OAuthKitTests/OAuthProvidersTests.swift
+++ b/Tests/OAuthKitTests/OAuthProvidersTests.swift
@@ -22,7 +22,7 @@ import Testing
 @Suite("OAuth Providers Tests")
 struct OAuthProvidersTests {
     var logger = Logger(label: "OAuthProvidersTests")
-    var oauthKit = OAuthKit(httpClient: HTTPClient.shared, logger: Logger(label: "provider-test"))
+    var oauthKit = OAuthClientFactory(httpClient: HTTPClient.shared, logger: Logger(label: "provider-test"))
 
     private let keycloakURL = ProcessInfo.processInfo.environment["KEYCLOAK_URL"] ?? "http://localhost:8080"
     private let redirectURI = "http://localhost:8080/callback"

--- a/Tests/OAuthKitTests/OpenIDConnectTests.swift
+++ b/Tests/OAuthKitTests/OpenIDConnectTests.swift
@@ -22,7 +22,7 @@ import Testing
 @Suite("OpenID Connect Tests")
 struct OpenIDConnectTests {
     var logger: Logger = Logger(label: "OpenIDConnectTests")
-    var oauthKit: OAuthKit = OAuthKit(httpClient: .shared, logger: Logger(label: "OAuthKitTest"))
+    var oauthKit: OAuthClientFactory = OAuthClientFactory(httpClient: .shared, logger: Logger(label: "OAuthKitTest"))
 
     private let keycloakURL = ProcessInfo.processInfo.environment["KEYCLOAK_URL"] ?? "http://localhost:8080"
     private let redirectURI = "http://localhost:8080/callback"


### PR DESCRIPTION
Refactored the main entry point struct from OAuthKit to OAuthClientFactory across all source files, providers, and tests. Updated documentation and usage examples in README.md to reflect the new name for improved clarity and consistency. This closes #16