### PR TITLE
Add MicrosoftTenantIDKind for flexible tenant config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           echo "Keycloak ready!"
 
       - name: Build
-        run: swift build --build-tests --configuration debug -Xswiftc -enable-testing -Xswiftc -warnings-as-errors -Xcc -Werror
+        run: swift build --build-tests --configuration debug -Xswiftc -enable-testing -Xswiftc -warnings-as-errors
       - name: Run Tests
         run: |
           swift test --skip-build --configuration debug --disable-xctest

--- a/Package.swift
+++ b/Package.swift
@@ -15,9 +15,9 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.25.2"),
-        .package(url: "https://github.com/vapor/jwt-kit.git", from: "5.1.2"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.3"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.30.0"),
+        .package(url: "https://github.com/vapor/jwt-kit.git", from: "5.3.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.4"),
     ],
     targets: [
         .target(

--- a/Sources/OAuthKit/OAuthClientFactory.swift
+++ b/Sources/OAuthKit/OAuthClientFactory.swift
@@ -111,49 +111,27 @@ public struct OAuthClientFactory: Sendable {
     }
 
     /// Create a Microsoft OAuth provider for Microsoft 365 / Azure AD Sign-In
-    /// for multi-tenant applications
     /// - Parameters:
     ///   - clientID: The client/application ID from Azure portal
     ///   - clientSecret: The client secret from Azure portal
     ///   - redirectURI: The redirect URI registered with Azure
+    ///   - tenantKind: The type of Microsoft tenant to authenticate against (defaults to .common for multi-tenant)
     /// - Returns: A Microsoft OAuth provider
-    public func microsoftMultiTenantProvider(
-        clientID: String,
-        clientSecret: String,
-        redirectURI: String
-    ) async throws -> MicrosoftOAuthProvider {
-        MicrosoftOAuthProvider(
-            oauthKit: self,
-            openIDConnectClient: try await openIDConnectClient(
-                discoveryURL: MicrosoftOAuthProvider.commonDiscoveryURL,
-                clientID: clientID,
-                clientSecret: clientSecret,
-                redirectURI: redirectURI
-            )
-        )
-    }
-
-    /// Create a Microsoft OpenID Connect client for a specific tenant
-    /// - Parameters:
-    ///   - clientID: The client/application ID from Azure portal
-    ///   - clientSecret: The client secret from Azure portal
-    ///   - tenantID: The Azure AD tenant ID
-    ///   - redirectURI: The redirect URI registered with Azure
-    /// - Returns: An OpenID Connect client configured for Microsoft
     public func microsoftProvider(
         clientID: String,
         clientSecret: String,
-        tenantID: String,
-        redirectURI: String
+        redirectURI: String,
+        tenantKind: MicrosoftTenantIDKind = .common
     ) async throws -> MicrosoftOAuthProvider {
         MicrosoftOAuthProvider(
             oauthKit: self,
             openIDConnectClient: try await openIDConnectClient(
-                discoveryURL: MicrosoftOAuthProvider.tenantDiscoveryURL(tenantID: tenantID),
+                discoveryURL: MicrosoftOAuthProvider.discoveryURL(for: tenantKind),
                 clientID: clientID,
                 clientSecret: clientSecret,
                 redirectURI: redirectURI
-            )
+            ),
+            tenantKind: tenantKind
         )
     }
 

--- a/Sources/OAuthKit/Providers/MicrosoftOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/MicrosoftOAuthProvider.swift
@@ -22,11 +22,11 @@ public struct MicrosoftOAuthProvider: Sendable {
     /// Microsoft's common (multi-tenant) OAuth2/OIDC discovery URL
     public static let commonDiscoveryURL = "https://login.microsoftonline.com/common/v2.0/"
 
-    /// Generate Microsoft's tenant-specific discovery URL
-    /// - Parameter tenantID: The Azure AD tenant ID
-    /// - Returns: The discovery URL for the specified tenant
-    public static func tenantDiscoveryURL(tenantID: String) -> String {
-        "https://login.microsoftonline.com/\(tenantID)/v2.0/"
+    /// Generate Microsoft's discovery URL for a specific tenant kind
+    /// - Parameter tenantKind: The Microsoft tenant kind
+    /// - Returns: The discovery URL for the specified tenant kind
+    public static func discoveryURL(for tenantKind: MicrosoftTenantIDKind) -> String {
+        tenantKind.discoveryURL
     }
 
     /// The OAuthKit instance
@@ -35,12 +35,18 @@ public struct MicrosoftOAuthProvider: Sendable {
     /// The OpenID Connect client configured for Microsoft
     private let client: OpenIDConnectClient
 
+    /// The tenant kind this provider is configured for
+    public let tenantKind: MicrosoftTenantIDKind
+
     /// Initialize a new Microsoft OAuth provider
-    /// - Parameter oauthKit: The OAuthKit instance
-    /// - Parameter openIDConnectClient: The OpenID Connect client configured for Microsoft
-    internal init(oauthKit: OAuthClientFactory, openIDConnectClient client: OpenIDConnectClient) {
+    /// - Parameters:
+    ///   - oauthKit: The OAuthKit instance
+    ///   - openIDConnectClient: The OpenID Connect client configured for Microsoft
+    ///   - tenantKind: The tenant kind this provider is configured for
+    internal init(oauthKit: OAuthClientFactory, openIDConnectClient client: OpenIDConnectClient, tenantKind: MicrosoftTenantIDKind) {
         self.oauthKit = oauthKit
         self.client = client
+        self.tenantKind = tenantKind
     }
 
     /// Generate an authorization URL for Microsoft Sign-In with recommended parameters

--- a/Sources/OAuthKit/Providers/MicrosoftTenantIDKind.swift
+++ b/Sources/OAuthKit/Providers/MicrosoftTenantIDKind.swift
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oauth-kit open source project
+//
+// Copyright (c) 2025 the oauth-kit project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of oauth-kit project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Defines the different types of Microsoft tenant IDs for Azure AD authentication
+public enum MicrosoftTenantIDKind: Sendable, Equatable {
+    /// Users with both a personal Microsoft account and a work or school account from Microsoft Entra ID can sign in to the application.
+    /// This enables multi-tenant scenarios where the application accepts both consumer and organizational accounts.
+    case common
+
+    /// Only users with a personal Microsoft account can sign in to the application.
+    /// This restricts authentication to consumer accounts only (e.g., @outlook.com, @hotmail.com, @live.com).
+    case consumers
+
+    /// Only users with work or school accounts from Microsoft Entra ID can sign in to the application.
+    /// This restricts authentication to organizational accounts only.
+    case organizations
+
+    /// Only users from a specific Microsoft Entra tenant (directory members with a work or school account
+    /// or directory guests with a personal Microsoft account) can sign in to the application.
+    /// The value can be the domain name of the Microsoft Entra tenant or the tenant ID in GUID format.
+    /// - Parameter tenantIdentifier: The tenant ID (GUID format) or domain name (e.g., "contoso.com" or "8eaef023-2b34-4da1-9baa-8bc8c9d6a490")
+    case custom(String)
+}
+
+extension MicrosoftTenantIDKind {
+    /// Returns the string value to be used in Microsoft OAuth URLs
+    public var value: String {
+        switch self {
+        case .common:
+            return "common"
+        case .consumers:
+            return "consumers"
+        case .organizations:
+            return "organizations"
+        case .custom(let tenantIdentifier):
+            return tenantIdentifier
+        }
+    }
+
+    /// Generates the Microsoft OAuth2/OIDC discovery URL for this tenant kind
+    public var discoveryURL: String {
+        "https://login.microsoftonline.com/\(value)/v2.0/"
+    }
+
+    /// Creates a MicrosoftTenantIDKind from a string value
+    /// - Parameter value: The tenant identifier string
+    /// - Returns: The corresponding MicrosoftTenantIDKind case
+    public static func from(value: String) -> MicrosoftTenantIDKind {
+        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        switch trimmedValue.lowercased() {
+        case "", "common":
+            return .common
+        case "consumers":
+            return .consumers
+        case "organizations":
+            return .organizations
+        default:
+            return .custom(trimmedValue)
+        }
+    }
+}
+
+extension MicrosoftTenantIDKind: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .common:
+            return "common (multi-tenant)"
+        case .consumers:
+            return "consumers (personal accounts only)"
+        case .organizations:
+            return "organizations (work/school accounts only)"
+        case .custom(let tenantIdentifier):
+            return "custom tenant (\(tenantIdentifier))"
+        }
+    }
+}
+
+extension MicrosoftTenantIDKind: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self = .from(value: value)
+    }
+}
+
+extension MicrosoftTenantIDKind: RawRepresentable {
+    public var rawValue: String {
+        value
+    }
+
+    public init?(rawValue: String) {
+        self = .from(value: rawValue)
+    }
+}

--- a/Tests/OAuthKitTests/MicrosoftTenantIDKindTests.swift
+++ b/Tests/OAuthKitTests/MicrosoftTenantIDKindTests.swift
@@ -1,0 +1,291 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the oauth-kit open source project
+//
+// Copyright (c) 2025 the oauth-kit project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of oauth-kit project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import OAuthKit
+
+@Suite("MicrosoftTenantIDKind Tests")
+struct MicrosoftTenantIDKindTests {
+
+    // MARK: - Basic enum value tests
+
+    @Test("Common tenant kind properties")
+    func commonTenantKind() {
+        let tenantKind = MicrosoftTenantIDKind.common
+        #expect(tenantKind.value == "common")
+        #expect(tenantKind.discoveryURL == "https://login.microsoftonline.com/common/v2.0/")
+        #expect(tenantKind.description == "common (multi-tenant)")
+    }
+
+    @Test("Consumers tenant kind properties")
+    func consumersTenantKind() {
+        let tenantKind = MicrosoftTenantIDKind.consumers
+        #expect(tenantKind.value == "consumers")
+        #expect(tenantKind.discoveryURL == "https://login.microsoftonline.com/consumers/v2.0/")
+        #expect(tenantKind.description == "consumers (personal accounts only)")
+    }
+
+    @Test("Organizations tenant kind properties")
+    func organizationsTenantKind() {
+        let tenantKind = MicrosoftTenantIDKind.organizations
+        #expect(tenantKind.value == "organizations")
+        #expect(tenantKind.discoveryURL == "https://login.microsoftonline.com/organizations/v2.0/")
+        #expect(tenantKind.description == "organizations (work/school accounts only)")
+    }
+
+    @Test("Custom tenant kind with GUID")
+    func customTenantKindWithGUID() {
+        let tenantId = "8eaef023-2b34-4da1-9baa-8bc8c9d6a490"
+        let tenantKind = MicrosoftTenantIDKind.custom(tenantId)
+        #expect(tenantKind.value == tenantId)
+        #expect(tenantKind.discoveryURL == "https://login.microsoftonline.com/\(tenantId)/v2.0/")
+        #expect(tenantKind.description == "custom tenant (\(tenantId))")
+    }
+
+    @Test("Custom tenant kind with domain")
+    func customTenantKindWithDomain() {
+        let domain = "contoso.com"
+        let tenantKind = MicrosoftTenantIDKind.custom(domain)
+        #expect(tenantKind.value == domain)
+        #expect(tenantKind.discoveryURL == "https://login.microsoftonline.com/\(domain)/v2.0/")
+        #expect(tenantKind.description == "custom tenant (\(domain))")
+    }
+
+    // MARK: - From value factory method tests
+
+    @Test("From value factory method - common")
+    func fromValueCommon() {
+        let tenantKind = MicrosoftTenantIDKind.from(value: "common")
+        #expect(tenantKind == .common)
+    }
+
+    @Test("From value factory method - common case insensitive")
+    func fromValueCommonCaseInsensitive() {
+        let tenantKind = MicrosoftTenantIDKind.from(value: "COMMON")
+        #expect(tenantKind == .common)
+    }
+
+    @Test("From value factory method - consumers")
+    func fromValueConsumers() {
+        let tenantKind = MicrosoftTenantIDKind.from(value: "consumers")
+        #expect(tenantKind == .consumers)
+    }
+
+    @Test("From value factory method - consumers case insensitive")
+    func fromValueConsumersCaseInsensitive() {
+        let tenantKind = MicrosoftTenantIDKind.from(value: "CONSUMERS")
+        #expect(tenantKind == .consumers)
+    }
+
+    @Test("From value factory method - organizations")
+    func fromValueOrganizations() {
+        let tenantKind = MicrosoftTenantIDKind.from(value: "organizations")
+        #expect(tenantKind == .organizations)
+    }
+
+    @Test("From value factory method - organizations case insensitive")
+    func fromValueOrganizationsCaseInsensitive() {
+        let tenantKind = MicrosoftTenantIDKind.from(value: "ORGANIZATIONS")
+        #expect(tenantKind == .organizations)
+    }
+
+    @Test("From value factory method - custom GUID")
+    func fromValueCustomGUID() {
+        let tenantId = "8eaef023-2b34-4da1-9baa-8bc8c9d6a490"
+        let tenantKind = MicrosoftTenantIDKind.from(value: tenantId)
+        #expect(tenantKind == .custom(tenantId))
+    }
+
+    @Test("From value factory method - custom domain")
+    func fromValueCustomDomain() {
+        let domain = "contoso.com"
+        let tenantKind = MicrosoftTenantIDKind.from(value: domain)
+        #expect(tenantKind == .custom(domain))
+    }
+
+    @Test("From value factory method - empty string defaults to common")
+    func fromValueEmptyString() {
+        let tenantKind = MicrosoftTenantIDKind.from(value: "")
+        #expect(tenantKind == .common)
+    }
+
+    @Test("From value factory method - whitespace only defaults to common")
+    func fromValueWhitespaceOnly() {
+        let tenantKind = MicrosoftTenantIDKind.from(value: "   ")
+        #expect(tenantKind == .common)
+    }
+
+    // MARK: - RawRepresentable tests
+
+    @Test("RawRepresentable conformance - common")
+    func rawRepresentableCommon() {
+        let tenantKind = MicrosoftTenantIDKind.common
+        #expect(tenantKind.rawValue == "common")
+
+        let fromRaw = MicrosoftTenantIDKind(rawValue: "common")
+        #expect(fromRaw == .common)
+    }
+
+    @Test("RawRepresentable conformance - consumers")
+    func rawRepresentableConsumers() {
+        let tenantKind = MicrosoftTenantIDKind.consumers
+        #expect(tenantKind.rawValue == "consumers")
+
+        let fromRaw = MicrosoftTenantIDKind(rawValue: "consumers")
+        #expect(fromRaw == .consumers)
+    }
+
+    @Test("RawRepresentable conformance - organizations")
+    func rawRepresentableOrganizations() {
+        let tenantKind = MicrosoftTenantIDKind.organizations
+        #expect(tenantKind.rawValue == "organizations")
+
+        let fromRaw = MicrosoftTenantIDKind(rawValue: "organizations")
+        #expect(fromRaw == .organizations)
+    }
+
+    @Test("RawRepresentable conformance - custom")
+    func rawRepresentableCustom() {
+        let tenantId = "8eaef023-2b34-4da1-9baa-8bc8c9d6a490"
+        let tenantKind = MicrosoftTenantIDKind.custom(tenantId)
+        #expect(tenantKind.rawValue == tenantId)
+
+        let fromRaw = MicrosoftTenantIDKind(rawValue: tenantId)
+        #expect(fromRaw == .custom(tenantId))
+    }
+
+    @Test("RawRepresentable conformance - empty string defaults to common")
+    func rawRepresentableEmptyString() {
+        let fromRaw = MicrosoftTenantIDKind(rawValue: "")
+        #expect(fromRaw == .common)
+        #expect(fromRaw?.rawValue == "common")
+    }
+
+    @Test("RawRepresentable conformance - whitespace defaults to common")
+    func rawRepresentableWhitespace() {
+        let fromRaw = MicrosoftTenantIDKind(rawValue: "   ")
+        #expect(fromRaw == .common)
+        #expect(fromRaw?.rawValue == "common")
+    }
+
+    // MARK: - ExpressibleByStringLiteral tests
+
+    @Test("String literal support - common")
+    func stringLiteralCommon() {
+        let tenantKind: MicrosoftTenantIDKind = "common"
+        #expect(tenantKind == .common)
+    }
+
+    @Test("String literal support - consumers")
+    func stringLiteralConsumers() {
+        let tenantKind: MicrosoftTenantIDKind = "consumers"
+        #expect(tenantKind == .consumers)
+    }
+
+    @Test("String literal support - organizations")
+    func stringLiteralOrganizations() {
+        let tenantKind: MicrosoftTenantIDKind = "organizations"
+        #expect(tenantKind == .organizations)
+    }
+
+    @Test("String literal support - custom GUID")
+    func stringLiteralCustomGUID() {
+        let tenantId = "8eaef023-2b34-4da1-9baa-8bc8c9d6a490"
+        let tenantKind: MicrosoftTenantIDKind = "8eaef023-2b34-4da1-9baa-8bc8c9d6a490"
+        #expect(tenantKind == .custom(tenantId))
+    }
+
+    @Test("String literal support - custom domain")
+    func stringLiteralCustomDomain() {
+        let domain = "contoso.com"
+        let tenantKind: MicrosoftTenantIDKind = "contoso.com"
+        #expect(tenantKind == .custom(domain))
+    }
+
+    @Test("String literal support - empty string defaults to common")
+    func stringLiteralEmptyString() {
+        let tenantKind: MicrosoftTenantIDKind = ""
+        #expect(tenantKind == .common)
+    }
+
+    @Test("String literal support - whitespace only defaults to common")
+    func stringLiteralWhitespaceOnly() {
+        let tenantKind: MicrosoftTenantIDKind = "   "
+        #expect(tenantKind == .common)
+    }
+
+    // MARK: - Equatable tests
+
+    @Test("Equality - same cases")
+    func equalitySameCases() {
+        #expect(MicrosoftTenantIDKind.common == MicrosoftTenantIDKind.common)
+        #expect(MicrosoftTenantIDKind.consumers == MicrosoftTenantIDKind.consumers)
+        #expect(MicrosoftTenantIDKind.organizations == MicrosoftTenantIDKind.organizations)
+
+        let tenantId = "8eaef023-2b34-4da1-9baa-8bc8c9d6a490"
+        #expect(MicrosoftTenantIDKind.custom(tenantId) == MicrosoftTenantIDKind.custom(tenantId))
+    }
+
+    @Test("Inequality - different custom values")
+    func inequalityCustomDifferent() {
+        #expect(MicrosoftTenantIDKind.custom("tenant1") != MicrosoftTenantIDKind.custom("tenant2"))
+    }
+
+    @Test("Inequality - different cases")
+    func inequalityDifferentCases() {
+        #expect(MicrosoftTenantIDKind.common != MicrosoftTenantIDKind.consumers)
+        #expect(MicrosoftTenantIDKind.consumers != MicrosoftTenantIDKind.organizations)
+        #expect(MicrosoftTenantIDKind.common != MicrosoftTenantIDKind.custom("test"))
+    }
+
+    // MARK: - Discovery URL format tests
+
+    @Test("Discovery URL formats correctly for all cases")
+    func discoveryURLFormats() {
+        let testCases: [(MicrosoftTenantIDKind, String)] = [
+            (.common, "https://login.microsoftonline.com/common/v2.0/"),
+            (.consumers, "https://login.microsoftonline.com/consumers/v2.0/"),
+            (.organizations, "https://login.microsoftonline.com/organizations/v2.0/"),
+            (.custom("contoso.com"), "https://login.microsoftonline.com/contoso.com/v2.0/"),
+            (.custom("8eaef023-2b34-4da1-9baa-8bc8c9d6a490"), "https://login.microsoftonline.com/8eaef023-2b34-4da1-9baa-8bc8c9d6a490/v2.0/"),
+        ]
+
+        for (tenantKind, expectedURL) in testCases {
+            #expect(tenantKind.discoveryURL == expectedURL)
+        }
+    }
+
+    // MARK: - Edge cases
+
+    @Test("Custom tenant can accept any non-empty string")
+    func customTenantAcceptsAnyValue() {
+        let customValue = "any-custom-value"
+        let tenantKind = MicrosoftTenantIDKind.custom(customValue)
+        #expect(tenantKind.value == customValue)
+        #expect(tenantKind.discoveryURL == "https://login.microsoftonline.com/\(customValue)/v2.0/")
+    }
+
+    // MARK: - Static factory method on MicrosoftOAuthProvider
+
+    @Test("MicrosoftOAuthProvider discoveryURL factory method")
+    func microsoftOAuthProviderDiscoveryURL() {
+        let commonURL = MicrosoftOAuthProvider.discoveryURL(for: .common)
+        #expect(commonURL == "https://login.microsoftonline.com/common/v2.0/")
+
+        let customURL = MicrosoftOAuthProvider.discoveryURL(for: .custom("contoso.com"))
+        #expect(customURL == "https://login.microsoftonline.com/contoso.com/v2.0/")
+    }
+}


### PR DESCRIPTION
Introduces the MicrosoftTenantIDKind enum to support flexible configuration of Microsoft OAuth providers for multi-tenant, consumer, organization, and custom tenant scenarios. Updates OAuthClientFactory and MicrosoftOAuthProvider to use tenantKind instead of raw tenantID, refactors related API, and adds comprehensive documentation and tests for tenant kind handling. Also updates dependencies and improves README usage examples.