### PR TITLE
Add provider params and update docs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,17 +15,25 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.30.0"),
-        .package(url: "https://github.com/vapor/jwt-kit.git", from: "5.3.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.33.1"),
+        .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
+        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.4"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.97.1"),
+        .package(url: "https://github.com/vapor/jwt-kit.git", from: "5.4.0"),
     ],
     targets: [
         .target(
             name: "OAuthKit",
             dependencies: [
+                .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
                 .product(name: "JWTKit", package: "jwt-kit"),
+                .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
             ]
         ),
         .testTarget(

--- a/Sources/OAuthKit/OAuth2ClientProtocol.swift
+++ b/Sources/OAuthKit/OAuth2ClientProtocol.swift
@@ -63,7 +63,6 @@ extension OAuth2ClientProtocol {
     ///   - tokenEndpoint: The OAuth2 token endpoint
     ///   - authorizationEndpoint:The OAuth2 authorization endpoint
     ///   - redirectURI: The redirect URI registered with the OAuth2 provider
-    ///   - scopes: The requested scopes
     ///   - logger: Logger used for OAuth2Client operations
     public init(
         httpClient: HTTPClient = HTTPClient.shared,
@@ -188,7 +187,9 @@ extension OAuth2ClientProtocol {
     }
 
     /// Request a token using client credentials grant
-    /// - Parameter additionalParameters: Additional parameters to include in the token request
+    /// - Parameters:
+    ///   - additionalParameters: Additional parameters to include in the token request
+    ///   - scopes: The requested OAuth scopes
     /// - Returns: The token response
     /// - Throws: OAuth2Error if the token request fails
     public func clientCredentials(

--- a/Sources/OAuthKit/OAuthClientFactory.swift
+++ b/Sources/OAuthKit/OAuthClientFactory.swift
@@ -279,7 +279,6 @@ public struct OAuthClientFactory: Sendable {
     ///   - clientID: The client ID from GitHub
     ///   - clientSecret: The client secret from GitHub
     ///   - redirectURI: The redirect URI registered with GitHub
-    ///   - scope: The requested scopes (space-separated)
     /// - Returns: A GitHub OAuth provider
     public func githubProvider(
         clientID: String,
@@ -422,6 +421,13 @@ public struct OAuthClientFactory: Sendable {
     }
 
     /// Create an Apple OAuth provider for Sign in with Apple
+    /// - Parameters:
+    ///   - clientID: The client/service ID from Apple Developer portal
+    ///   - teamID: The Team ID from Apple Developer portal
+    ///   - keyID: The Key ID for the Sign in with Apple private key
+    ///   - privateKey: The private key content in PEM format
+    ///   - clientSecret: The client secret
+    ///   - redirectURI: The redirect URI registered with Apple
     /// - Returns: An Apple OAuth provider
     public func appleProvider(
         clientID: String,
@@ -499,7 +505,6 @@ public struct OAuthClientFactory: Sendable {
     ///   - clientID: The client ID from Okta
     ///   - clientSecret: The client secret from Okta
     ///   - redirectURI: The redirect URI registered with Okta
-    ///   - scopes: The requested scopes
     ///   - useCustomAuth: Whether to use the custom authorization server (default: false)
     ///   - authServerId: The authorization server ID for custom auth server (default: "default")
     /// - Returns: An Okta OAuth provider
@@ -520,7 +525,10 @@ public struct OAuthClientFactory: Sendable {
                 clientID: clientID,
                 clientSecret: clientSecret,
                 redirectURI: redirectURI
-            )
+            ),
+            domain: domain,
+            useCustomAuth: useCustomAuth,
+            authServerId: authServerId
         )
     }
 
@@ -531,7 +539,6 @@ public struct OAuthClientFactory: Sendable {
     ///   - clientID: The client ID from Cognito (App client ID)
     ///   - clientSecret: The client secret from Cognito (optional, as not all app clients have secrets)
     ///   - redirectURI: The redirect URI registered with Cognito
-    ///   - scopes: The requested scopes (space-separated)
     ///   - domain: Optional custom domain for your Cognito user pool (if you've set one up)
     /// - Returns: An AWS Cognito OAuth provider
     public func awsCognitoProvider(
@@ -555,10 +562,15 @@ public struct OAuthClientFactory: Sendable {
             redirectURI: redirectURI
         )
 
-        return AWSCognitoOAuthProvider(oauthKit: self, openIDConnectClient: client)
+        return AWSCognitoOAuthProvider(oauthKit: self, openIDConnectClient: client, region: region, userPoolID: userPoolID, domain: domain)
     }
 
     /// Create a KeyCloak OAuth provider for Sign in with KeyCloak
+    /// - Parameters:
+    ///   - endpoints: The KeyCloak endpoint configuration (token, authorization, etc.)
+    ///   - clientID: The client ID from KeyCloak
+    ///   - clientSecret: The client secret from KeyCloak
+    ///   - redirectURI: The redirect URI registered with KeyCloak
     /// - Returns: A KeyCloak OAuth provider
     public func keycloakProvider(
         endpoints: KeyCloakOAuthProvider.Endpoints,

--- a/Sources/OAuthKit/OpenID/OpenIDConnectClient.swift
+++ b/Sources/OAuthKit/OpenID/OpenIDConnectClient.swift
@@ -86,7 +86,7 @@ public struct OpenIDConnectClient: Sendable {
     ///   - codeChallenge: PKCE code challenge (if using PKCE)
     ///   - codeChallengeMethod: PKCE code challenge method (e.g., "S256")
     ///   - additionalParameters: Additional query parameters to include in the URL
-    ///   - scope: The requested scopes
+    ///   - scopes: The requested scopes
     /// - Returns: The authorization URL
     /// - Throws: OAuth2Error if the authorization endpoint is not configured
     public func generateAuthorizationURL(

--- a/Sources/OAuthKit/Providers/AWSCognitoOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/AWSCognitoOAuthProvider.swift
@@ -25,15 +25,33 @@ public struct AWSCognitoOAuthProvider {
     /// An OpenID Connect client configured for AWS Cognito
     private let client: OpenIDConnectClient
 
+    /// The AWS region where the user pool is located
+    public let region: String
+
+    /// The Cognito User Pool ID
+    public let userPoolID: String
+
+    /// Optional custom domain for the Cognito user pool
+    public let domain: String?
+
     /// Initialize a new AWS Cognito OAuth provider
     /// - Parameter oauthKit: The OAuthKit instance
     /// - Parameter openIDConnectClient: The OpenID Connect client configured for AWS Cognito
+    /// - Parameter region: The AWS region where the user pool is located
+    /// - Parameter userPoolID: The Cognito User Pool ID
+    /// - Parameter domain: Optional custom domain for the Cognito user pool
     internal init(
         oauthKit: OAuthClientFactory,
-        openIDConnectClient client: OpenIDConnectClient
+        openIDConnectClient client: OpenIDConnectClient,
+        region: String,
+        userPoolID: String,
+        domain: String? = nil
     ) {
         self.oauthKit = oauthKit
         self.client = client
+        self.region = region
+        self.userPoolID = userPoolID
+        self.domain = domain
     }
 
     /// Build the AWS Cognito OpenID Connect discovery URL
@@ -102,7 +120,8 @@ public struct AWSCognitoOAuthProvider {
         }
 
         // Choose which authorization URL to use
-        if let cognitoDomain = cognitoDomain {
+        let effectiveDomain = cognitoDomain ?? self.domain
+        if let cognitoDomain = effectiveDomain {
             // If a specific Cognito domain is provided, use it (for hosted UI)
             let sanitizedDomain = cognitoDomain.trimmingCharacters(in: .whitespaces).lowercased()
             let baseURL = sanitizedDomain.hasPrefix("https://") ? sanitizedDomain : "https://\(sanitizedDomain)"

--- a/Sources/OAuthKit/Providers/AppleOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/AppleOAuthProvider.swift
@@ -75,10 +75,12 @@ public struct AppleOAuthProvider {
 
     /// Generate an authorization URL for Apple Sign In
     /// - Parameters:
-    ///   - client: The OAuth2 client configured for Apple
     ///   - state: An opaque value to maintain state between the request and callback
     ///   - usePKCE: Whether to use PKCE (recommended and enabled by default)
+    ///   - responseMode: The response mode for the authorization (defaults to `.query`)
+    ///   - responseType: The response types to request (defaults to `[.code]`)
     ///   - additionalParameters: Additional parameters to include in the authorization URL
+    ///   - scopes: The requested scopes (defaults to `["name", "email"]`)
     /// - Returns: A tuple containing the authorization URL and code verifier (for PKCE)
     public func getAuthorizationURL(
         state: String? = nil,
@@ -234,6 +236,16 @@ public struct AppleOAuth2Client: OAuth2ClientProtocol {
 
     /// Initialize a new Apple OAuth2 client
     ///
+    /// - Parameters:
+    ///   - httpClient: The HTTP client for making requests
+    ///   - clientID: The client/service ID from Apple Developer portal
+    ///   - clientSecret: The client secret
+    ///   - teamID: The Team ID from Apple Developer portal
+    ///   - keyID: The Key ID for the Sign in with Apple private key
+    ///   - privateKey: The private key content in PEM format
+    ///   - redirectURI: The redirect URI registered with Apple
+    ///   - jwksURL: The URL for Apple's JSON Web Key Set
+    ///   - logger: Logger for OAuth operations
     public init(
         httpClient: HTTPClient = HTTPClient.shared,
         clientID: String,

--- a/Sources/OAuthKit/Providers/FacebookOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/FacebookOAuthProvider.swift
@@ -43,6 +43,7 @@ public struct FacebookOAuthProvider: Sendable {
 
     /// Initialize a new Facebook OAuth provider
     /// - Parameter oauthKit: The OAuthKit instance
+    /// - Parameter client: The OAuth2 client configured for Facebook
     public init(oauthKit: OAuthClientFactory, client: OAuth2Client) {
         self.oauthKit = oauthKit
         self.client = client
@@ -54,6 +55,7 @@ public struct FacebookOAuthProvider: Sendable {
     ///   - usePKCE: Whether to use PKCE (Facebook now supports PKCE)
     ///   - displayMode: The display mode for the Facebook authentication dialog
     ///   - additionalParameters: Additional parameters to include in the authorization URL
+    ///   - scopes: The requested OAuth scopes (defaults to `["email", "public_profile"]`)
     /// - Returns: A tuple containing the authorization URL and code verifier (for PKCE)
     public func generateAuthorizationURL(
         state: String? = nil,
@@ -97,6 +99,7 @@ public struct FacebookOAuthProvider: Sendable {
     /// - Parameters:
     ///   - code: The authorization code received from Facebook
     ///   - codeVerifier: The PKCE code verifier used when generating the authorization URL
+    ///   - additionalParameters: Additional parameters to include in the token request
     /// - Returns: The token response
     public func exchangeCode(
         code: String,

--- a/Sources/OAuthKit/Providers/GitHubOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/GitHubOAuthProvider.swift
@@ -53,10 +53,10 @@ public struct GitHubOAuthProvider: Sendable {
 
     /// Generate an authorization URL for GitHub login
     /// - Parameters:
-    ///   - client: The OAuth2 client configured for GitHub
     ///   - state: An opaque value to maintain state between the request and callback
     ///   - usePKCE: Whether to use PKCE (GitHub now supports PKCE as of 2023)
     ///   - additionalParameters: Additional parameters to include in the authorization URL
+    ///   - scopes: The requested OAuth scopes (defaults to `["read:user", "user:email"]`)
     /// - Returns: A tuple containing the authorization URL and code verifier (for PKCE)
     public func signInURL(
         state: String? = nil,
@@ -88,6 +88,7 @@ public struct GitHubOAuthProvider: Sendable {
     /// - Parameters:
     ///   - code: The authorization code received from GitHub
     ///   - codeVerifier: The PKCE code verifier used when generating the authorization URL
+    ///   - additionalParameters: Additional parameters to include in the token request
     /// - Returns: The token response
     public func exchangeCode(
         code: String,

--- a/Sources/OAuthKit/Providers/KeyCloakOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/KeyCloakOAuthProvider.swift
@@ -128,6 +128,7 @@ public struct KeyCloakOAuthProvider: Sendable {
     ///   - loginHint: Optional email/username hint for pre-filling the login form
     ///   - locale: Optional locale for the KeyCloak UI (e.g., "en")
     ///   - prompt: Optional prompt behavior (login, none, consent)
+    ///   - additionalParameters: Additional parameters to include in the authorization URL
     ///   - scopes: The requested scopes
     /// - Returns: A tuple containing the authorization URL and PKCE code verifier (if used)
     public func generateAuthorizationURL(

--- a/Sources/OAuthKit/Providers/OktaOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/OktaOAuthProvider.swift
@@ -26,11 +26,28 @@ public struct OktaOAuthProvider: Sendable {
     /// An OpenID Connect client configured for Okta
     private let client: OpenIDConnectClient
 
+    /// The Okta domain (e.g. "dev-123456.okta.com")
+    public let domain: String
+
+    /// Whether to use the custom authorization server
+    public let useCustomAuth: Bool
+
+    /// The authorization server ID for custom auth server
+    public let authServerId: String
+
     /// Initialize a new Okta OAuth provider
-    /// - Parameter oauthKit: The OAuthKit instance
-    internal init(oauthKit: OAuthClientFactory, client: OpenIDConnectClient) {
+    /// - Parameters:
+    ///   - oauthKit: The OAuthKit instance
+    ///   - client: The OpenID Connect client
+    ///   - domain: The Okta domain
+    ///   - useCustomAuth: Whether to use the custom authorization server
+    ///   - authServerId: The authorization server ID for custom auth server
+    internal init(oauthKit: OAuthClientFactory, client: OpenIDConnectClient, domain: String, useCustomAuth: Bool, authServerId: String) {
         self.oauthKit = oauthKit
         self.client = client
+        self.domain = domain
+        self.useCustomAuth = useCustomAuth
+        self.authServerId = authServerId
     }
 
     /// Build the Okta OpenID Connect discovery URL
@@ -58,6 +75,7 @@ public struct OktaOAuthProvider: Sendable {
     ///   - prompt: Controls the Okta sign-in prompt behavior
     ///   - idpID: The identity provider ID to bypass the Okta sign-in page and go directly to the specified IdP
     ///   - usePKCE: Whether to use PKCE (recommended and enabled by default)
+    ///   - additionalParameters: Additional parameters to include in the authorization URL
     ///   - scopes: The requested scopes
     /// - Returns: A tuple containing the authorization URL and code verifier (for PKCE)
     public func generateAuthorizationURL(
@@ -406,14 +424,14 @@ public struct OktaOAuthProvider: Sendable {
 
     // MARK: - Helper Methods
 
-    /// Extract base URL from OpenID Connect configuration
+    /// Base URL for Okta API calls, derived from the stored domain
     private func extractBaseURL() -> String {
-        let issuer = client.configuration.issuer
-        // Remove /.well-known/openid_configuration or /oauth2/default if present
-        if issuer.contains("/oauth2/") {
-            return String(issuer.prefix(while: { $0 != "/" }) + "://" + issuer.drop(while: { $0 != "/" }).dropFirst().prefix(while: { $0 != "/" }))
+        let sanitizedDomain = domain.trimmingCharacters(in: .whitespaces).lowercased()
+        let base = sanitizedDomain.hasPrefix("https://") ? sanitizedDomain : "https://\(sanitizedDomain)"
+        if useCustomAuth {
+            return "\(base)/oauth2/\(authServerId)"
         }
-        return issuer
+        return base
     }
 
     /// Make authenticated API request to Okta

--- a/Sources/OAuthKit/Providers/SlackOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/SlackOAuthProvider.swift
@@ -51,6 +51,7 @@ public struct SlackOAuthProvider {
     /// - Parameters:
     ///   - state: An opaque value to maintain state between the request and callback
     ///   - usePKCE: Whether to use PKCE (supported by Slack)
+    ///   - scopes: The requested OAuth scopes
     ///   - userScope: Additional user scopes for Slack user tokens
     ///   - additionalParameters: Additional parameters to include in the authorization URL
     /// - Returns: A tuple containing the authorization URL and code verifier (for PKCE)
@@ -237,10 +238,11 @@ public struct SlackOAuth2Client: OAuth2ClientProtocol {
         self.logger = logger
     }
 
-    /// Exchange an authorization code for tokens with GitHub
+    /// Exchange an authorization code for tokens with Slack
     /// - Parameters:
     ///   - code: The authorization code received from Slack
     ///   - codeVerifier: The PKCE code verifier used when generating the authorization URL
+    ///   - additionalParameters: Additional parameters to include in the token request
     /// - Returns: The token response
     public func exchangeCode(
         code: String,


### PR DESCRIPTION
Introduce explicit configuration parameters for providers and tidy up documentation. AWSCognitoOAuthProvider now stores region, userPoolID and optional domain, and the factory forwards those values when creating the provider. OktaOAuthProvider now stores domain, useCustomAuth and authServerId and derives the base URL accordingly (supports custom auth servers). OAuthClientFactory signatures and returns updated to pass new provider args. Numerous doc comments were clarified across OAuth2/OpenID and provider implementations (scopes/parameters, PKCE, response modes/types, and additionalParameters for token/authorization flows) to reflect supported options and defaults.