### PR TITLE
Redirect url override improvements

### DIFF
--- a/Sources/OAuthKit/OAuth2ClientProtocol.swift
+++ b/Sources/OAuthKit/OAuth2ClientProtocol.swift
@@ -98,13 +98,14 @@ extension OAuth2ClientProtocol {
         codeChallenge: String?,
         codeChallengeMethod: OAuthCodeChallengeMethod? = .s256,
         additionalParameters: [String: String],
-        scopes: [String]
+        scopes: [String],
+        redirectURIOverride: String? = nil
     ) throws -> URL {
         guard let authorizationEndpoint = authorizationEndpoint else {
             throw OAuth2Error.configurationError("Authorization endpoint is required but not configured")
         }
 
-        guard let redirectURI = redirectURI else {
+        guard let redirectURI = redirectURIOverride ?? redirectURI else {
             throw OAuth2Error.configurationError("Redirect URI is required for authorization flow but not configured")
         }
 
@@ -160,9 +161,10 @@ extension OAuth2ClientProtocol {
     public func getToken(
         code: String,
         codeVerifier: String?,
-        additionalParameters: [String: String]
+        additionalParameters: [String: String],
+        redirectURIOverride: String? = nil
     ) async throws -> TokenResponse {
-        guard let redirectURI = redirectURI else {
+        guard let redirectURI = redirectURIOverride ?? redirectURI else {
             throw OAuth2Error.configurationError("Redirect URI is required for authorization code exchange but not configured")
         }
 
@@ -701,7 +703,7 @@ extension OAuth2ClientProtocol {
     /// - Throws: OAuth2Error if the request fails
     internal func requestTokenIntrospection(parameters: [String: String]) async throws -> TokenIntrospectionResponse {
         // Use conventional introspection endpoint pattern
-        let baseURL = tokenEndpoint.replacingOccurrences(of: "/token", with: "")
+        let baseURL = tokenEndpoint.replacing("/token", with: "")
         let introspectionEndpoint = "\(baseURL)/introspect"
 
         guard let url = URL(string: introspectionEndpoint) else {
@@ -792,7 +794,7 @@ extension OAuth2ClientProtocol {
     /// - Throws: OAuth2Error if the request fails
     internal func requestTokenRevocation(parameters: [String: String]) async throws -> TokenRevocationResponse {
         // Use conventional revocation endpoint pattern
-        let baseURL = tokenEndpoint.replacingOccurrences(of: "/token", with: "")
+        let baseURL = tokenEndpoint.replacing("/token", with: "")
         let revocationEndpoint = "\(baseURL)/revoke"
 
         guard let url = URL(string: revocationEndpoint) else {

--- a/Sources/OAuthKit/OpenID/JWKSRefreshService.swift
+++ b/Sources/OAuthKit/OpenID/JWKSRefreshService.swift
@@ -193,12 +193,14 @@ public final class JWKSRefreshService: Service {
 
     /// Entry point called by `ServiceGroup`.
     ///
-    /// Performs an initial refresh of every registered endpoint, then enters a
-    /// dynamic sleep loop. The service wakes at the earliest `nextRefreshAt`
-    /// across all endpoints (capped at `configuration.refreshInterval`) and
-    /// refreshes only the endpoints that are actually due. Graceful shutdown is
-    /// handled by task cancellation, which causes `Task.sleep` to throw
-    /// `CancellationError` and unwind the loop.
+    /// Performs an initial refresh, then loops with dynamic sleep until
+    /// graceful shutdown.
+    ///
+    /// `cancelWhenGracefulShutdown(_:)` from ServiceLifecycle runs the loop in
+    /// a child task and cancels it the moment graceful shutdown is triggered,
+    /// so `Task.sleep` throws `CancellationError` immediately rather than
+    /// waiting for the full sleep interval to expire. The loop condition
+    /// `!Task.isShuttingDownGracefully` provides an additional clean exit path.
     public func run() async throws {
         logger.info(
             "Starting JWKS refresh service",
@@ -207,10 +209,14 @@ public final class JWKSRefreshService: Service {
 
         await refreshDueEndpoints()
 
-        while true {
-            try await Task.sleep(until: nextWakeupInstant(), clock: ContinuousClock())
-            await refreshDueEndpoints()
+        try await cancelWhenGracefulShutdown {
+            while !Task.isCancelled && !Task.isShuttingDownGracefully {
+                try await Task.sleep(until: self.nextWakeupInstant(), clock: ContinuousClock())
+                await self.refreshDueEndpoints()
+            }
         }
+
+        logger.info("JWKS refresh service stopped")
     }
 
     // MARK: - Manual refresh

--- a/Sources/OAuthKit/OpenID/OpenIDConnectClient.swift
+++ b/Sources/OAuthKit/OpenID/OpenIDConnectClient.swift
@@ -123,12 +123,14 @@ public struct OpenIDConnectClient: Sendable {
     public func exchangeCode(
         code: String,
         codeVerifier: String? = nil,
-        additionalParameters: [String: String] = [:]
+        additionalParameters: [String: String] = [:],
+        redirectURIOverride: String? = nil
     ) async throws -> (tokenResponse: TokenResponse, claims: IDTokenClaims) {
         let tokenResponse = try await oauth2Client.getToken(
             code: code,
             codeVerifier: codeVerifier,
-            additionalParameters: additionalParameters
+            additionalParameters: additionalParameters,
+            redirectURIOverride: redirectURIOverride
         )
 
         // Verify and decode the ID token

--- a/Sources/OAuthKit/OpenID/OpenIDConnectClient.swift
+++ b/Sources/OAuthKit/OpenID/OpenIDConnectClient.swift
@@ -102,14 +102,16 @@ public struct OpenIDConnectClient: Sendable {
         codeChallenge: String? = nil,
         codeChallengeMethod: OAuthCodeChallengeMethod? = nil,
         additionalParameters: [String: String] = [:],
-        scopes: [String] = ["openid", "profile", "email", "offline_access"]
+        scopes: [String] = ["openid", "profile", "email", "offline_access"],
+        redirectURIOverride: String? = nil
     ) throws -> URL {
         try oauth2Client.generateAuthorizationURL(
             state: state,
             codeChallenge: codeChallenge,
             codeChallengeMethod: codeChallengeMethod,
             additionalParameters: additionalParameters,
-            scopes: scopes
+            scopes: scopes,
+            redirectURIOverride: redirectURIOverride
         )
     }
 

--- a/Sources/OAuthKit/Providers/AWSCognitoOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/AWSCognitoOAuthProvider.swift
@@ -89,7 +89,8 @@ public struct AWSCognitoOAuthProvider {
         usePKCE: Bool = true,
         cognitoDomain: String? = nil,
         additionalParameters: [String: String] = [:],
-        scopes: [String] = ["openid", "profile", "email", "offline_access"]
+        scopes: [String] = ["openid", "profile", "email", "offline_access"],
+        redirectURIOverride: String? = nil
     ) throws -> (url: URL, codeVerifier: String?) {
 
         var codeVerifier: String? = nil
@@ -133,7 +134,7 @@ public struct AWSCognitoOAuthProvider {
             var queryItems = [
                 URLQueryItem(name: "client_id", value: client.clientID),
                 URLQueryItem(name: "response_type", value: "code"),
-                URLQueryItem(name: "redirect_uri", value: client.redirectURI),
+                URLQueryItem(name: "redirect_uri", value: redirectURIOverride ?? client.redirectURI),
             ]
 
             // Optional parameters
@@ -168,7 +169,8 @@ public struct AWSCognitoOAuthProvider {
                 state: state,
                 codeChallenge: codeChallenge,
                 additionalParameters: additionalParams,
-                scopes: scopes
+                scopes: scopes,
+                redirectURIOverride: redirectURIOverride
             )
 
             return (url, codeVerifier)
@@ -182,11 +184,13 @@ public struct AWSCognitoOAuthProvider {
     /// - Returns: A tuple containing the token response and ID token claims
     public func exchangeCode(
         code: String,
-        codeVerifier: String? = nil
+        codeVerifier: String? = nil,
+        redirectURIOverride: String? = nil
     ) async throws -> (tokenResponse: TokenResponse, claims: IDTokenClaims) {
         try await client.exchangeCode(
             code: code,
-            codeVerifier: codeVerifier
+            codeVerifier: codeVerifier,
+            redirectURIOverride: redirectURIOverride
         )
     }
 

--- a/Sources/OAuthKit/Providers/AppleOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/AppleOAuthProvider.swift
@@ -88,7 +88,8 @@ public struct AppleOAuthProvider {
         responseMode: ResponseMode = .query,
         responseType: [ResponseType] = [.code],
         additionalParameters: [String: String] = [:],
-        scopes: [String] = ["name", "email"]
+        scopes: [String] = ["name", "email"],
+        redirectURIOverride: String? = nil
     ) throws -> (url: URL, codeVerifier: String?) {
 
         var codeVerifier: String? = nil
@@ -114,7 +115,8 @@ public struct AppleOAuthProvider {
             state: state,
             codeChallenge: codeChallenge,
             additionalParameters: params,
-            scopes: scopes
+            scopes: scopes,
+            redirectURIOverride: redirectURIOverride
         )
 
         return (url, codeVerifier)
@@ -127,7 +129,8 @@ public struct AppleOAuthProvider {
     /// - Returns: The token response
     public func exchangeCode(
         code: String,
-        codeVerifier: String? = nil
+        codeVerifier: String? = nil,
+        redirectURIOverride: String? = nil
     ) async throws -> TokenResponse {
 
         let parameters = [
@@ -137,7 +140,8 @@ public struct AppleOAuthProvider {
         return try await client.getToken(
             code: code,
             codeVerifier: codeVerifier,
-            additionalParameters: parameters
+            additionalParameters: parameters,
+            redirectURIOverride: redirectURIOverride
         )
     }
 

--- a/Sources/OAuthKit/Providers/Auth0OAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/Auth0OAuthProvider.swift
@@ -63,7 +63,8 @@ public struct Auth0OAuthProvider: Sendable {
         audience: String? = nil,
         usePKCE: Bool = true,
         additionalParameters: [String: String] = [:],
-        scopes: [String] = ["openid", "profile", "email"]
+        scopes: [String] = ["openid", "profile", "email"],
+        redirectURIOverride: String? = nil
     ) throws -> (url: URL, codeVerifier: String?) {
         var additionalParams = additionalParameters
         var codeVerifier: String? = nil
@@ -94,7 +95,8 @@ public struct Auth0OAuthProvider: Sendable {
             state: state,
             codeChallenge: codeChallenge,
             additionalParameters: additionalParams,
-            scopes: scopes
+            scopes: scopes,
+            redirectURIOverride: redirectURIOverride
         )
 
         return (url, codeVerifier)
@@ -107,11 +109,13 @@ public struct Auth0OAuthProvider: Sendable {
     /// - Returns: The token response and ID token claims
     public func exchangeCode(
         code: String,
-        codeVerifier: String?
+        codeVerifier: String?,
+        redirectURIOverride: String? = nil
     ) async throws -> (tokenResponse: TokenResponse, claims: IDTokenClaims) {
         try await client.exchangeCode(
             code: code,
-            codeVerifier: codeVerifier
+            codeVerifier: codeVerifier,
+            redirectURIOverride: redirectURIOverride
         )
     }
 

--- a/Sources/OAuthKit/Providers/DiscordOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/DiscordOAuthProvider.swift
@@ -64,7 +64,8 @@ public struct DiscordOAuthProvider: Sendable {
         permissions: DiscordPermissions? = nil,
         usePKCE: Bool = true,
         additionalParameters: [String: String] = [:],
-        scopes: [String] = ["identify", "email"]
+        scopes: [String] = ["identify", "email"],
+        redirectURIOverride: String? = nil
     ) throws -> (url: URL, codeVerifier: String?) {
         var additionalParams = additionalParameters
         var codeVerifier: String? = nil
@@ -99,7 +100,8 @@ public struct DiscordOAuthProvider: Sendable {
             state: state,
             codeChallenge: codeChallenge,
             additionalParameters: additionalParams,
-            scopes: scopes
+            scopes: scopes,
+            redirectURIOverride: redirectURIOverride
         )
 
         return (url, codeVerifier)
@@ -112,12 +114,14 @@ public struct DiscordOAuthProvider: Sendable {
     /// - Returns: The token response
     public func exchangeCode(
         code: String,
-        codeVerifier: String?
+        codeVerifier: String?,
+        redirectURIOverride: String? = nil
     ) async throws -> TokenResponse {
         try await client.getToken(
             code: code,
             codeVerifier: codeVerifier,
-            additionalParameters: [:]
+            additionalParameters: [:],
+            redirectURIOverride: redirectURIOverride
         )
     }
 

--- a/Sources/OAuthKit/Providers/DropboxOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/DropboxOAuthProvider.swift
@@ -69,7 +69,8 @@ public struct DropboxOAuthProvider: Sendable {
         forceReauthentication: Bool = false,
         usePKCE: Bool = true,
         additionalParameters: [String: String] = [:],
-        scopes: [DropboxScope] = []
+        scopes: [DropboxScope] = [],
+        redirectURIOverride: String? = nil
     ) throws -> (url: URL, codeVerifier: String?) {
         var additionalParams = additionalParameters
         var codeVerifier: String? = nil
@@ -113,7 +114,8 @@ public struct DropboxOAuthProvider: Sendable {
             state: state,
             codeChallenge: codeChallenge,
             additionalParameters: additionalParams,
-            scopes: []  // Scopes handled above in additionalParams
+            scopes: [],  // Scopes handled above in additionalParams
+            redirectURIOverride: redirectURIOverride
         )
 
         return (url, codeVerifier)
@@ -126,12 +128,14 @@ public struct DropboxOAuthProvider: Sendable {
     /// - Returns: The token response
     public func exchangeCode(
         code: String,
-        codeVerifier: String?
+        codeVerifier: String?,
+        redirectURIOverride: String? = nil
     ) async throws -> TokenResponse {
         try await client.getToken(
             code: code,
             codeVerifier: codeVerifier,
-            additionalParameters: [:]
+            additionalParameters: [:],
+            redirectURIOverride: redirectURIOverride
         )
     }
 

--- a/Sources/OAuthKit/Providers/FacebookOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/FacebookOAuthProvider.swift
@@ -62,7 +62,8 @@ public struct FacebookOAuthProvider: Sendable {
         usePKCE: Bool = true,
         displayMode: FacebookDisplayMode? = nil,
         additionalParameters: [String: String] = [:],
-        scopes: [String] = ["email", "public_profile"]
+        scopes: [String] = ["email", "public_profile"],
+        redirectURIOverride: String? = nil
     ) throws -> (url: URL, codeVerifier: String?) {
         var codeVerifier: String? = nil
         var codeChallenge: String? = nil
@@ -89,7 +90,8 @@ public struct FacebookOAuthProvider: Sendable {
             state: state,
             codeChallenge: codeChallenge,
             additionalParameters: params,
-            scopes: scopes
+            scopes: scopes,
+            redirectURIOverride: redirectURIOverride
         )
 
         return (url, codeVerifier)
@@ -104,12 +106,14 @@ public struct FacebookOAuthProvider: Sendable {
     public func exchangeCode(
         code: String,
         codeVerifier: String? = nil,
-        additionalParameters: [String: String] = [:]
+        additionalParameters: [String: String] = [:],
+        redirectURIOverride: String? = nil
     ) async throws -> TokenResponse {
         try await client.getToken(
             code: code,
             codeVerifier: codeVerifier,
-            additionalParameters: additionalParameters
+            additionalParameters: additionalParameters,
+            redirectURIOverride: redirectURIOverride
         )
     }
 

--- a/Sources/OAuthKit/Providers/GitHubOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/GitHubOAuthProvider.swift
@@ -62,7 +62,8 @@ public struct GitHubOAuthProvider: Sendable {
         state: String? = nil,
         usePKCE: Bool = true,
         additionalParameters: [String: String] = [:],
-        scopes: [String] = ["read:user", "user:email"]
+        scopes: [String] = ["read:user", "user:email"],
+        redirectURIOverride: String? = nil
     ) throws -> (url: URL, codeVerifier: String?) {
         var codeVerifier: String? = nil
         var codeChallenge: String? = nil
@@ -78,7 +79,8 @@ public struct GitHubOAuthProvider: Sendable {
             state: state,
             codeChallenge: codeChallenge,
             additionalParameters: additionalParameters,
-            scopes: scopes
+            scopes: scopes,
+            redirectURIOverride: redirectURIOverride
         )
 
         return (url, codeVerifier)
@@ -93,12 +95,14 @@ public struct GitHubOAuthProvider: Sendable {
     public func exchangeCode(
         code: String,
         codeVerifier: String? = nil,
-        additionalParameters: [String: String] = [:]
+        additionalParameters: [String: String] = [:],
+        redirectURIOverride: String? = nil
     ) async throws -> TokenResponse {
         try await client.getToken(
             code: code,
             codeVerifier: codeVerifier,
-            additionalParameters: additionalParameters
+            additionalParameters: additionalParameters,
+            redirectURIOverride: redirectURIOverride
         )
     }
 

--- a/Sources/OAuthKit/Providers/GitLabOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/GitLabOAuthProvider.swift
@@ -82,7 +82,8 @@ public struct GitLabOAuthProvider: Sendable {
         state: String? = nil,
         usePKCE: Bool = true,
         additionalParameters: [String: String] = [:],
-        scopes: [GitLabScope] = [.readUser]
+        scopes: [GitLabScope] = [.readUser],
+        redirectURIOverride: String? = nil
     ) throws -> (url: URL, codeVerifier: String?) {
         let additionalParams = additionalParameters
         var codeVerifier: String? = nil
@@ -99,7 +100,8 @@ public struct GitLabOAuthProvider: Sendable {
             state: state,
             codeChallenge: codeChallenge,
             additionalParameters: additionalParams,
-            scopes: scopes.map { $0.rawValue }
+            scopes: scopes.map { $0.rawValue },
+            redirectURIOverride: redirectURIOverride
         )
 
         return (url, codeVerifier)
@@ -112,12 +114,14 @@ public struct GitLabOAuthProvider: Sendable {
     /// - Returns: The token response
     public func exchangeCode(
         code: String,
-        codeVerifier: String?
+        codeVerifier: String?,
+        redirectURIOverride: String? = nil
     ) async throws -> TokenResponse {
         try await client.getToken(
             code: code,
             codeVerifier: codeVerifier,
-            additionalParameters: [:]
+            additionalParameters: [:],
+            redirectURIOverride: redirectURIOverride
         )
     }
 

--- a/Sources/OAuthKit/Providers/GoogleOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/GoogleOAuthProvider.swift
@@ -66,7 +66,8 @@ public struct GoogleOAuthProvider: Sendable {
         accessType: TokenAccessType = .offline,
         includeGrantedScopes: Bool = true,
         additionalParameters: [String: String] = [:],
-        scopes: [String]
+        scopes: [String],
+        redirectURIOverride: String? = nil
     ) throws -> (url: URL, codeVerifier: String?) {
         var additionalParams = additionalParameters
         var codeVerifier: String? = nil
@@ -102,7 +103,8 @@ public struct GoogleOAuthProvider: Sendable {
             state: state,
             codeChallenge: codeChallenge,
             additionalParameters: additionalParams,
-            scopes: scopes
+            scopes: scopes,
+            redirectURIOverride: redirectURIOverride
         )
 
         return (url, codeVerifier)
@@ -147,11 +149,13 @@ public struct GoogleOAuthProvider: Sendable {
     /// - Returns: The token response and ID token claims
     public func exchangeCode(
         code: String,
-        codeVerifier: String?
+        codeVerifier: String?,
+        redirectURIOverride: String? = nil
     ) async throws -> (tokenResponse: TokenResponse, claims: IDTokenClaims) {
         try await client.exchangeCode(
             code: code,
-            codeVerifier: codeVerifier
+            codeVerifier: codeVerifier,
+            redirectURIOverride: redirectURIOverride
         )
     }
 

--- a/Sources/OAuthKit/Providers/KeyCloakOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/KeyCloakOAuthProvider.swift
@@ -133,7 +133,8 @@ public struct KeyCloakOAuthProvider: Sendable {
         locale: String? = nil,
         prompt: Prompt? = nil,
         additionalParameters: [String: String] = [:],
-        scopes: [String] = ["openid", "profile", "email"]
+        scopes: [String] = ["openid", "profile", "email"],
+        redirectURIOverride: String? = nil
     ) throws -> (url: URL, codeVerifier: String?) {
         var additionalParams: [String: String] = [:]
 
@@ -164,7 +165,8 @@ public struct KeyCloakOAuthProvider: Sendable {
             state: state,
             codeChallenge: codeChallenge,
             additionalParameters: additionalParams,
-            scopes: scopes
+            scopes: scopes,
+            redirectURIOverride: redirectURIOverride
         )
 
         return (url, codeVerifier)

--- a/Sources/OAuthKit/Providers/LinkedInOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/LinkedInOAuthProvider.swift
@@ -56,7 +56,8 @@ public struct LinkedInOAuthProvider: Sendable {
         state: String? = nil,
         usePKCE: Bool = true,
         additionalParameters: [String: String] = [:],
-        scopes: [String] = ["openid", "profile", "email"]
+        scopes: [String] = ["openid", "profile", "email"],
+        redirectURIOverride: String? = nil
     ) throws -> (url: URL, codeVerifier: String?) {
         let additionalParams = additionalParameters
         var codeVerifier: String? = nil
@@ -73,7 +74,8 @@ public struct LinkedInOAuthProvider: Sendable {
             state: state,
             codeChallenge: codeChallenge,
             additionalParameters: additionalParams,
-            scopes: scopes
+            scopes: scopes,
+            redirectURIOverride: redirectURIOverride
         )
 
         return (url, codeVerifier)
@@ -86,12 +88,14 @@ public struct LinkedInOAuthProvider: Sendable {
     /// - Returns: The token response
     public func exchangeCode(
         code: String,
-        codeVerifier: String?
+        codeVerifier: String?,
+        redirectURIOverride: String? = nil
     ) async throws -> TokenResponse {
         try await client.getToken(
             code: code,
             codeVerifier: codeVerifier,
-            additionalParameters: [:]
+            additionalParameters: [:],
+            redirectURIOverride: redirectURIOverride
         )
     }
 

--- a/Sources/OAuthKit/Providers/MicrosoftOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/MicrosoftOAuthProvider.swift
@@ -66,7 +66,8 @@ public struct MicrosoftOAuthProvider: Sendable {
         domainHint: MicrosoftDomainHint? = nil,
         usePKCE: Bool = true,
         additionalParameters: [String: String] = [:],
-        scopes: [String] = ["openid", "profile", "email", "offline_access", "User.Read"]
+        scopes: [String] = ["openid", "profile", "email", "offline_access", "User.Read"],
+        redirectURIOverride: String? = nil
     ) throws -> (url: URL, codeVerifier: String?) {
         var additionalParams = additionalParameters
         var codeVerifier: String? = nil
@@ -105,7 +106,8 @@ public struct MicrosoftOAuthProvider: Sendable {
             state: state,
             codeChallenge: codeChallenge,
             additionalParameters: additionalParams,
-            scopes: scopes
+            scopes: scopes,
+            redirectURIOverride: redirectURIOverride
         )
 
         return (url, codeVerifier)
@@ -118,11 +120,13 @@ public struct MicrosoftOAuthProvider: Sendable {
     /// - Returns: The token response and ID token claims
     public func exchangeCode(
         code: String,
-        codeVerifier: String?
+        codeVerifier: String?,
+        redirectURIOverride: String? = nil
     ) async throws -> (tokenResponse: TokenResponse, claims: IDTokenClaims) {
         try await client.exchangeCode(
             code: code,
-            codeVerifier: codeVerifier
+            codeVerifier: codeVerifier,
+            redirectURIOverride: redirectURIOverride
         )
     }
 

--- a/Sources/OAuthKit/Providers/OktaOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/OktaOAuthProvider.swift
@@ -84,7 +84,8 @@ public struct OktaOAuthProvider: Sendable {
         idpID: String? = nil,
         usePKCE: Bool = true,
         additionalParameters: [String: String] = [:],
-        scopes: [String] = ["openid", "profile", "email", "offline_access"]
+        scopes: [String] = ["openid", "profile", "email", "offline_access"],
+        redirectURIOverride: String? = nil
     ) async throws -> (url: URL, codeVerifier: String?) {
         var codeVerifier: String? = nil
         var codeChallenge: String? = nil
@@ -113,7 +114,8 @@ public struct OktaOAuthProvider: Sendable {
             state: state,
             codeChallenge: codeChallenge,
             additionalParameters: additionalParams,
-            scopes: scopes
+            scopes: scopes,
+            redirectURIOverride: redirectURIOverride
         )
 
         return (url, codeVerifier)
@@ -126,11 +128,13 @@ public struct OktaOAuthProvider: Sendable {
     /// - Returns: A tuple containing the token response and ID token claims
     public func exchangeCode(
         code: String,
-        codeVerifier: String? = nil
+        codeVerifier: String? = nil,
+        redirectURIOverride: String? = nil
     ) async throws -> (tokenResponse: TokenResponse, claims: IDTokenClaims) {
         try await client.exchangeCode(
             code: code,
-            codeVerifier: codeVerifier
+            codeVerifier: codeVerifier,
+            redirectURIOverride: redirectURIOverride
         )
     }
 

--- a/Sources/OAuthKit/Providers/SlackOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/SlackOAuthProvider.swift
@@ -60,7 +60,8 @@ public struct SlackOAuthProvider {
         usePKCE: Bool = true,
         scopes: [String] = [],
         userScope: [String]? = nil,
-        additionalParameters: [String: String] = [:]
+        additionalParameters: [String: String] = [:],
+        redirectURIOverride: String? = nil
     ) throws -> (url: URL, codeVerifier: String?) {
         var codeVerifier: String? = nil
         var codeChallenge: String? = nil
@@ -84,7 +85,8 @@ public struct SlackOAuthProvider {
             state: state,
             codeChallenge: codeChallenge,
             additionalParameters: additionalParams,
-            scopes: scopes
+            scopes: scopes,
+            redirectURIOverride: redirectURIOverride
         )
 
         return (url, codeVerifier)
@@ -97,11 +99,13 @@ public struct SlackOAuthProvider {
     /// - Returns: The Slack token response with additional Slack-specific data
     public func exchangeCode(
         code: String,
-        codeVerifier: String? = nil
+        codeVerifier: String? = nil,
+        redirectURIOverride: String? = nil
     ) async throws -> TokenResponse {  // we should be returning SlackTokenResponse
         let tokenResponse = try await client.exchangeCode(
             code: code,
-            codeVerifier: codeVerifier
+            codeVerifier: codeVerifier,
+            redirectURIOverride: redirectURIOverride
         )
 
         return tokenResponse
@@ -247,14 +251,16 @@ public struct SlackOAuth2Client: OAuth2ClientProtocol {
     public func exchangeCode(
         code: String,
         codeVerifier: String? = nil,
-        additionalParameters: [String: String] = [:]
+        additionalParameters: [String: String] = [:],
+        redirectURIOverride: String? = nil
     ) async throws -> TokenResponse {
         // TODO: make getToken return a generic type
         // So that a SlackTokenResponse is returned here instead
         try await getToken(
             code: code,
             codeVerifier: codeVerifier,
-            additionalParameters: additionalParameters
+            additionalParameters: additionalParameters,
+            redirectURIOverride: redirectURIOverride
         )
     }
 


### PR DESCRIPTION
Add an optional redirectURIOverride parameter across the OpenID client and all OAuth provider helpers so callers can override the configured redirect URI at runtime. The change propagates the new parameter into authorization URL generation and token exchange calls (generateAuthorizationURL, getToken, exchangeCode) for AWSCognito, Apple, Auth0, Discord, Dropbox, Facebook, GitHub, GitLab, KeyCloak, LinkedIn, Microsoft, Okta, Slack and the OpenIDConnectClient. This enables runtime redirect URI overrides for authorization and token flows without changing existing defaults.