### PR TITLE
Refactor Hummingbird docs and provider APIs

### DIFF
--- a/Sources/OAuthKit/OAuthKit.docc/DeviceFlowExample.md
+++ b/Sources/OAuthKit/OAuthKit.docc/DeviceFlowExample.md
@@ -121,7 +121,7 @@ struct OAuthCLI {
             clientID: getEnvVar("MICROSOFT_CLIENT_ID"),
             clientSecret: getEnvVar("MICROSOFT_CLIENT_SECRET"),
             redirectURI: "", // Not needed for device flow
-            tenantID: .common
+            tenantKind: .common
         )
         
         print("\n🔍 Starting Microsoft authentication...")
@@ -152,9 +152,9 @@ struct OAuthCLI {
     
     private func authenticateWithAuth0(factory: OAuthClientFactory) async throws -> UserInfo {
         let provider = try await factory.auth0Provider(
+            domain: getEnvVar("AUTH0_DOMAIN"),
             clientID: getEnvVar("AUTH0_CLIENT_ID"),
             clientSecret: getEnvVar("AUTH0_CLIENT_SECRET"),
-            domain: getEnvVar("AUTH0_DOMAIN"),
             redirectURI: "" // Not needed for device flow
         )
         

--- a/Sources/OAuthKit/OAuthKit.docc/HummingbirdIntegration.md
+++ b/Sources/OAuthKit/OAuthKit.docc/HummingbirdIntegration.md
@@ -1,22 +1,23 @@
 # Hummingbird Integration
 
-Learn how to integrate OAuthKit with the Hummingbird web framework using proper session management.
+Integrate OAuthKit with Hummingbird 2 using `HummingbirdAuth` for session management.
 
 ## Overview
 
-OAuthKit provides excellent integration with Hummingbird, Swift's modern, lightweight web framework. This guide demonstrates how to implement OAuth2 authentication in your Hummingbird applications using `HummingbirdAuth` for session management and proper async/await patterns.
+This guide shows how to add OAuth2 sign-in to a Hummingbird 2 application. It uses:
 
-## Basic Setup
+- **OAuthKit** for OAuth provider communication
+- **HummingbirdAuth** for session middleware, authenticator middleware, and request context protocols
+- **ServiceLifecycle** to wire services (OAuthKit's `OAuthClientFactory` is itself a `Service`)
 
-### Installation
-
-Add both OAuthKit and Hummingbird dependencies to your `Package.swift`:
+## Installation
 
 ```swift
+// Package.swift
 dependencies: [
     .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
     .package(url: "https://github.com/hummingbird-project/hummingbird-auth.git", from: "2.0.0"),
-    .package(url: "https://github.com/thoven87/oauth-kit.git", from: "1.0.0")
+    .package(url: "https://github.com/thoven87/oauth-kit.git", from: "1.0.0"),
 ],
 targets: [
     .executableTarget(
@@ -24,544 +25,470 @@ targets: [
         dependencies: [
             .product(name: "Hummingbird", package: "hummingbird"),
             .product(name: "HummingbirdAuth", package: "hummingbird-auth"),
-            .product(name: "OAuthKit", package: "oauth-kit")
+            .product(name: "OAuthKit", package: "oauth-kit"),
         ]
     )
 ]
 ```
 
-### Application Configuration
+## Session Model
 
-Set up your Hummingbird application with OAuth support:
+`HummingbirdAuth`'s sessions store **one typed value** per request. Define a `UserSession` struct that holds everything you want to persist across requests:
 
 ```swift
-import Hummingbird
 import HummingbirdAuth
 import OAuthKit
 
-struct User: Authenticatable, Codable, Sendable {
+/// The authenticated user stored in the session.
+/// `Sendable` (not `Authenticatable`) — the old HB1 protocol is removed.
+struct UserSession: Codable, Sendable {
     let id: String
     let name: String
     let email: String
+    let accessToken: String
+    let refreshToken: String?
+    /// Raw ID token — needed to build the provider end-session URL on logout.
+    let idToken: String?
+    /// Which provider authenticated this user ("google", "microsoft", etc.).
+    let provider: String
 }
 
-typealias AppRequestContext = BasicSessionRequestContext<String, User>
-
-func buildApplication(configuration: ApplicationConfiguration) async throws -> some ApplicationProtocol {
-    let router = Router(context: AppRequestContext.self)
-    
-    // Create OAuthKit factory
-    let oauthFactory = OAuthClientFactory()
-    
-    // Session storage (use appropriate storage for production)
-    let sessionStorage = MemorySessionStorage<String, User>(
-        expiration: .minutes(30)
-    )
-    
-    // Add middleware
-    router.addMiddleware {
-        LogRequestsMiddleware(.info)
-        CORSMiddleware()
-        SessionMiddleware(storage: sessionStorage)
-    }
-    
-    // Configure OAuth routes
-    try await configureOAuthRoutes(router, oauthFactory: oauthFactory)
-    
-    var application = Application(
-        router: router,
-        server: .http1(),
-        configuration: configuration
-    )
-    return application
+/// Short-lived OAuth handshake data stored separately (e.g. a signed cookie
+/// or an in-process Mutex dictionary) — NOT in the user session.
+struct OAuthHandshake: Sendable {
+    let state: String
+    let codeVerifier: String?
+    let provider: String
 }
+
+/// Request context: session key = String (cookie value), identity = UserSession.
+typealias AppRequestContext = BasicSessionRequestContext<String, UserSession>
 ```
 
-## OAuth Routes Implementation
+> **Why a separate `OAuthHandshake`?** Sessions in HummingbirdAuth store one value; a dictionary-style API does not exist. Short-lived OAuth state (the `state` and `code_verifier` parameters) should live outside the session — for example in a signed cookie or in a server-side `Mutex`-protected dictionary that is cleaned up after the callback.
 
-### Authorization Flow
+## Application Setup
 
 ```swift
 import Hummingbird
 import HummingbirdAuth
 import OAuthKit
+import ServiceLifecycle
+import Synchronization
 
+// In-process store for pending OAuth handshakes, keyed by `state` parameter.
+// Replace with Redis or a database in production.
+let pendingHandshakes: Mutex<[String: OAuthHandshake]> = Mutex([:])
+
+func buildApplication() async throws -> some ApplicationProtocol {
+    // Hummingbird's built-in Environment merges process env with a .env file.
+    // Keys are lowercased automatically; require(_:) throws instead of crashing.
+    let env = try await Environment().merging(with: Environment.dotEnv(".env"))
+    let oauthKit = OAuthClientFactory()
+    let persist = MemoryPersistDriver()
+    let sessionStorage = SessionStorage<UserSession>(persist)
+
+    let router = Router(context: AppRequestContext.self)
+    router.addMiddleware {
+        LogRequestsMiddleware(.info)
+        SessionMiddleware(storage: sessionStorage)
+    }
+
+    configureOAuthRoutes(router, oauthKit: oauthKit)
+    configureProtectedRoutes(router)
+
+    let app = Application(router: router, configuration: .init(address: .hostname("127.0.0.1", port: 8080)))
+
+    // OAuthClientFactory is a Service — add it to the ServiceGroup so JWKS
+    // keys are kept refreshed automatically.
+    return ServiceGroup(
+        configuration: .init(
+            services: [oauthKit, app],
+            gracefulShutdownSignals: [.sigterm, .sigint],
+            logger: Logger(label: "app")
+        )
+    )
+}
+```
+
+## OAuth Routes
+
+### Initiating the flow
+
+```swift
 func configureOAuthRoutes(
     _ router: Router<AppRequestContext>,
-    oauthFactory: OAuthClientFactory
-) async throws {
-    
-    // OAuth initialization routes
+    oauthKit: OAuthClientFactory
+) {
+    // Step 1 — redirect the browser to the provider.
     router.get("auth/:provider") { request, context async throws -> Response in
-        guard let providerName = context.parameters.get("provider") else {
-            throw HTTPError(.badRequest, reason: "Provider parameter required")
-        }
-        
-        let provider = try await createOAuthProvider(providerName, factory: oauthFactory)
+        let providerName = try context.parameters.require("provider")
+
         let state = UUID().uuidString
-        let (authURL, codeVerifier) = try provider.generateAuthURL(
+        let (authURL, codeVerifier) = try await makeAuthURL(
+            provider: providerName,
             state: state,
-            scopes: getScopesForProvider(providerName)
+            oauthKit: oauthKit
         )
-        
-        // Store OAuth state in session
-        context.sessions.setSession("oauth_state", state)
-        context.sessions.setSession("code_verifier", codeVerifier ?? "")
-        context.sessions.setSession("provider", providerName)
-        
-        return Response(
-            status: .seeOther,
-            headers: [.location: authURL.absoluteString]
-        )
+
+        // Store the handshake state until the callback arrives.
+        pendingHandshakes.withLock {
+            $0[state] = OAuthHandshake(
+                state: state,
+                codeVerifier: codeVerifier,
+                provider: providerName
+            )
+        }
+
+        return Response(status: .seeOther, headers: [.location: authURL.absoluteString])
     }
-    
-    // OAuth callback handling
+
+    // Step 2 — handle the provider callback.
     router.get("auth/:provider/callback") { request, context async throws -> Response in
-        guard let providerName = context.parameters.get("provider") else {
-            throw HTTPError(.badRequest, reason: "Provider parameter required")
-        }
-        
         let queryParams = request.uri.queryParameters
-        
-        // Verify state parameter
+
         guard let receivedState = queryParams.get("state"),
-              let storedState: String = context.sessions.getSession("oauth_state"),
-              receivedState == storedState else {
-            throw HTTPError(.badRequest, reason: "Invalid state parameter")
+              let handshake = pendingHandshakes.withLock({ $0.removeValue(forKey: receivedState) })
+        else {
+            throw HTTPError(.badRequest, message: "Invalid or expired state parameter")
         }
-        
+
         guard let code = queryParams.get("code") else {
-            throw HTTPError(.badRequest, reason: "Authorization code required")
+            throw HTTPError(.badRequest, message: "Authorization code required")
         }
-        
-        let codeVerifier: String? = context.sessions.getSession("code_verifier")
-        let provider = try await createOAuthProvider(providerName, factory: oauthFactory)
-        
-        do {
-            let (tokenResponse, claims) = try await provider.exchangeCode(
-                code: code,
-                codeVerifier: codeVerifier?.isEmpty == false ? codeVerifier : nil
-            )
-            
-            // Create user from OAuth response
-            let user = User(
-                id: claims?.sub?.value ?? UUID().uuidString,
-                name: claims?.name ?? "Unknown User",
-                email: claims?.email ?? ""
-            )
-            
-            // Set authenticated user session
-            context.sessions.setSession(user)
-            
-            // Store tokens for API access
-            context.sessions.setSession("access_token", tokenResponse.accessToken)
-            if let refreshToken = tokenResponse.refreshToken {
-                context.sessions.setSession("refresh_token", refreshToken)
-            }
-            
-            // Clear OAuth temporary data
-            context.sessions.clearSession("oauth_state")
-            context.sessions.clearSession("code_verifier")
-            context.sessions.clearSession("provider")
-            
-            return Response(
-                status: .seeOther,
-                headers: [.location: "/dashboard"]
-            )
-            
-        } catch {
-            context.logger.error("OAuth token exchange failed: \(error)")
-            throw HTTPError(.unauthorized, reason: "Authentication failed")
-        }
-    }
-    
-    // Logout
-    router.post("logout") { request, context async throws -> Response in
-        context.sessions.clearAll()
-        return Response(
-            status: .seeOther,
-            headers: [.location: "/"]
+
+        let (tokenResponse, claims) = try await exchangeCode(
+            provider: handshake.provider,
+            code: code,
+            codeVerifier: handshake.codeVerifier,
+            oauthKit: oauthKit
         )
+
+        let session = UserSession(
+            id: claims?.sub?.value ?? UUID().uuidString,
+            name: claims?.name ?? "Unknown",
+            email: claims?.email ?? "",
+            accessToken: tokenResponse.accessToken,
+            refreshToken: tokenResponse.refreshToken,
+            idToken: tokenResponse.idToken,
+            provider: handshake.provider
+        )
+
+        // Store the user session — one typed value, no dictionary.
+        context.sessions.setSession(session, expiresIn: .minutes(30))
+
+        return Response(status: .seeOther, headers: [.location: "/dashboard"])
+    }
+
+    // Logout — two layers:
+    // 1. Clear the local session (always).
+    // 2. Redirect to the provider's end-session endpoint if available (SSO logout),
+    //    so the provider also invalidates the session on its side.
+    router.post("logout") { request, context async throws -> Response in
+        let session = context.sessions.session
+        context.sessions.clearSession()
+
+        // If we stored an ID token, build the provider end-session URL.
+        // endSessionURL uses the OIDC discovery `end_session_endpoint`;
+        // not all providers support this (GitHub doesn't, Google/Microsoft do).
+        if let idToken = session?.idToken,
+           let providerName = session?.provider {
+            if let endSessionURL = try? await makeEndSessionURL(
+                provider: providerName,
+                idToken: idToken,
+                postLogoutRedirectURI: "http://localhost:8080/",
+                oauthKit: oauthKit
+            ) {
+                return Response(status: .seeOther, headers: [.location: endSessionURL.absoluteString])
+            }
+        }
+
+        return Response(status: .seeOther, headers: [.location: "/"])
     }
 }
 ```
 
-### Protected Routes
+### Provider helpers
 
-Create protected routes using session authentication:
+```swift
+/// Build the provider end-session (SSO logout) URL.
+/// Only OIDC providers that advertise `end_session_endpoint` in their
+/// discovery document support this — GitHub and other OAuth-only providers
+/// do not. Falls back to `nil` so the caller can skip the redirect.
+func makeEndSessionURL(
+    provider: String,
+    idToken: String,
+    postLogoutRedirectURI: String,
+    oauthKit: OAuthClientFactory
+) async throws -> URL? {
+    let env = try await Environment().merging(with: Environment.dotEnv(".env"))
+    switch provider.lowercased() {
+    case "google":
+        let p = try await oauthKit.googleProvider(
+            clientID: try env.require("google_client_id"),
+            clientSecret: try env.require("google_client_secret"),
+            redirectURI: try env.require("google_redirect_uri")
+        )
+        return try? p.revokeToken(
+            idToken: idToken,
+            postLogoutRedirectURI: postLogoutRedirectURI,
+            state: nil
+        )
+    case "microsoft":
+        let p = try await oauthKit.microsoftProvider(
+            clientID: try env.require("microsoft_client_id"),
+            clientSecret: try env.require("microsoft_client_secret"),
+            redirectURI: try env.require("microsoft_redirect_uri"),
+            tenantKind: .common
+        )
+        return try? p.endSessionURL(
+            idToken: idToken,
+            postLogoutRedirectURI: postLogoutRedirectURI
+        )
+    default:
+        return nil  // provider doesn't support end-session
+    }
+}
+
+func makeAuthURL(
+    provider: String,
+    state: String,
+    oauthKit: OAuthClientFactory
+) async throws -> (URL, String?) {
+    // Environment is Hummingbird's built-in type.
+    // Keys are lowercased; require(_:) throws Environment.Error if missing.
+    let env = try await Environment().merging(with: Environment.dotEnv(".env"))
+
+    switch provider.lowercased() {
+    case "google":
+        let p = try await oauthKit.googleProvider(
+            clientID: try env.require("google_client_id"),
+            clientSecret: try env.require("google_client_secret"),
+            redirectURI: try env.require("google_redirect_uri")
+        )
+        let (url, verifier) = try p.generateAuthURL(
+            state: state,
+            scopes: ["openid", "profile", "email"]
+        )
+        return (url, verifier)
+
+    case "microsoft":
+        let p = try await oauthKit.microsoftProvider(
+            clientID: try env.require("microsoft_client_id"),
+            clientSecret: try env.require("microsoft_client_secret"),
+            redirectURI: try env.require("microsoft_redirect_uri"),
+            tenantKind: .common
+        )
+        let (url, verifier) = try p.generateAuthorizationURL(
+            state: state,
+            scopes: ["openid", "profile", "email", "User.Read"]
+        )
+        return (url, verifier)
+
+    case "github":
+        let p = oauthKit.githubProvider(
+            clientID: try env.require("github_client_id"),
+            clientSecret: try env.require("github_client_secret"),
+            redirectURI: try env.require("github_redirect_uri")
+        )
+        let (url, verifier) = try p.signInURL(
+            state: state,
+            scopes: ["user:email", "read:user"]
+        )
+        return (url, verifier)
+
+    default:
+        throw HTTPError(.badRequest, message: "Unsupported provider: \(provider)")
+    }
+}
+
+func exchangeCode(
+    provider: String,
+    code: String,
+    codeVerifier: String?,
+    oauthKit: OAuthClientFactory
+) async throws -> (TokenResponse, IDTokenClaims?) {
+    let env = try await Environment().merging(with: Environment.dotEnv(".env"))
+
+    switch provider.lowercased() {
+    case "google":
+        let p = try await oauthKit.googleProvider(
+            clientID: try env.require("google_client_id"),
+            clientSecret: try env.require("google_client_secret"),
+            redirectURI: try env.require("google_redirect_uri")
+        )
+        let (tokenResponse, claims) = try await p.exchangeCode(
+            code: code, codeVerifier: codeVerifier
+        )
+        return (tokenResponse, claims)
+
+    case "microsoft":
+        let p = try await oauthKit.microsoftProvider(
+            clientID: try env.require("microsoft_client_id"),
+            clientSecret: try env.require("microsoft_client_secret"),
+            redirectURI: try env.require("microsoft_redirect_uri"),
+            tenantKind: .common
+        )
+        let (tokenResponse, claims) = try await p.exchangeCode(
+            code: code, codeVerifier: codeVerifier
+        )
+        return (tokenResponse, claims)
+
+    case "github":
+        let p = oauthKit.githubProvider(
+            clientID: try env.require("github_client_id"),
+            clientSecret: try env.require("github_client_secret"),
+            redirectURI: try env.require("github_redirect_uri")
+        )
+        let tokenResponse = try await p.exchangeCode(
+            code: code, codeVerifier: codeVerifier
+        )
+        return (tokenResponse, nil)
+
+    default:
+        throw HTTPError(.badRequest, message: "Unsupported provider: \(provider)")
+    }
+}
+```
+
+## Protected Routes
+
+Use `SessionAuthenticator` to restore the user from the session on each request:
 
 ```swift
 func configureProtectedRoutes(_ router: Router<AppRequestContext>) {
     let protected = router.group()
-        .add(middleware: SessionAuthenticator<String, User> { id, context in
-            // In a real app, you'd fetch from database
-            return context.sessions.getSession(id)
+        .add(middleware: SessionAuthenticator { (id: String, context) async throws -> UserSession? in
+            // Load from your database using `id` (the session cookie value).
+            // In this example we return the session value stored by setSession(_:).
+            return context.sessions.session
         })
-    
-    // Dashboard route
-    protected.get("dashboard") { request, context async throws -> DashboardResponse in
+        .add(middleware: IsAuthenticatedMiddleware<AppRequestContext>())
+
+    protected.get("dashboard") { request, context async throws -> Response in
         let user = try context.requireIdentity()
-        return DashboardResponse(
-            message: "Welcome, \(user.name)!",
-            user: user
+        return Response(
+            status: .ok,
+            body: .init(byteBuffer: .init(string: "Welcome, \(user.name)!"))
         )
     }
-    
-    // Profile route with API calls
-    protected.get("profile") { request, context async throws -> UserProfileResponse in
-        let user = try context.requireIdentity()
-        
-        // Make authenticated API call using stored token
-        guard let accessToken: String = context.sessions.getSession("access_token") else {
-            throw HTTPError(.unauthorized, reason: "No access token available")
-        }
-        
-        let profile = try await fetchUserProfile(accessToken: accessToken)
-        return UserProfileResponse(user: user, profile: profile)
-    }
-    
-    // API endpoint
-    protected.get("api/user") { request, context async throws -> User in
-        return try context.requireIdentity()
-    }
-}
 
-struct DashboardResponse: ResponseCodable {
-    let message: String
-    let user: User
-}
-
-struct UserProfileResponse: ResponseCodable {
-    let user: User
-    let profile: [String: String]
-}
-```
-
-## Provider Factory
-
-Create OAuth providers for different services:
-
-```swift
-func createOAuthProvider(
-    _ name: String,
-    factory: OAuthClientFactory
-) async throws -> any OAuth2Provider {
-    switch name.lowercased() {
-        
-    let env = Environment().merging(with: .dotEnv("../env"))    
-    
-    case "google":
-        return try await factory.googleProvider(
-            clientID: env.get("GOOGLE_CLIENT_ID")!,
-            clientSecret: env.get("GOOGLE_CLIENT_SECRET")!,
-            redirectURI: env.get("GOOGLE_REDIRECT_URI")!
-        )
-    case "microsoft":
-        return try await factory.microsoftProvider(
-            clientID: env.get("MICROSOFT_CLIENT_ID")!,
-            clientSecret: env.get("MICROSOFT_CLIENT_SECRET")!,
-            redirectURI: env.get("MICROSOFT_REDIRECT_URI")!,
-            tenantID: .common
-        )
-    case "github":
-        return try await factory.githubProvider(
-            clientID: env.get("GITHUB_CLIENT_ID")!,
-            clientSecret: env.get("GITHUB_CLIENT_SECRET")!,
-            redirectURI: env.get("GITHUB_REDIRECT_URI")!
-        )
-    case "discord":
-        return try await factory.discordProvider(
-            clientID: env.get("DISCORD_CLIENT_ID")!,
-            clientSecret: env.get("DISCORD_CLIENT_SECRET")!,
-            redirectURI: env.get("DISCORD_REDIRECT_URI")!
-        )
-    default:
-        throw HTTPError(.badRequest, reason: "Unsupported provider: \(name)")
-    }
-}
-
-func getScopesForProvider(_ provider: String) -> [String] {
-    switch provider.lowercased() {
-    case "google":
-        return ["openid", "profile", "email"]
-    case "microsoft":
-        return ["openid", "profile", "email", "User.Read"]
-    case "github":
-        return ["user:email", "read:user"]
-    case "discord":
-        return ["identify", "email"]
-    default:
-        return ["openid", "profile", "email"]
-    }
-}
-```
-
-## Session Extension Helpers
-
-Create convenient session extensions:
-
-```swift
-extension SessionProtocol {
-    func setSession<T>(_ key: String, _ value: T) where T: Codable {
-        self.setSession(SessionData(key: key, value: value))
-    }
-    
-    func getSession<T>(_ key: String) -> T? where T: Codable {
-        guard let data: SessionData<T> = self.getSession(key) else { return nil }
-        return data.value
-    }
-    
-    func clearSession(_ key: String) {
-        self.clearSession(key)
-    }
-    
-    func clearAll() {
-        // Implementation depends on your session storage
-    }
-}
-
-struct SessionData<T: Codable>: Codable {
-    let key: String
-    let value: T
-}
-```
-
-## Token Refresh Implementation
-
-Handle token refresh automatically:
-
-```swift
-struct TokenRefreshMiddleware<Context: SessionRequestContext>: RouterMiddleware 
-where Context.Identity == User {
-    
-    func handle(
-        _ request: Request,
-        context: Context,
-        next: (Request, Context) async throws -> Response
-    ) async throws -> Response {
-        
-        // Check if we have tokens that need refreshing
-        if let refreshToken: String = context.sessions.getSession("refresh_token"),
-           let expiresAt: Double = context.sessions.getSession("token_expires_at"),
-           let providerName: String = context.sessions.getSession("provider") {
-            
-            let now = Date().timeIntervalSince1970
-            if now >= expiresAt - 300 { // Refresh 5 minutes before expiry
-                do {
-                    let factory = OAuthClientFactory()
-                    let provider = try await createOAuthProvider(providerName, factory: factory)
-                    let (newTokens, _) = try await provider.refreshAccessToken(refreshToken: refreshToken)
-                    
-                    // Update session with new tokens
-                    context.sessions.setSession("access_token", newTokens.accessToken)
-                    if let newRefreshToken = newTokens.refreshToken {
-                        context.sessions.setSession("refresh_token", newRefreshToken)
-                    }
-                    let newExpiresAt = now + Double(newTokens.expiresIn ?? 3600)
-                    context.sessions.setSession("token_expires_at", newExpiresAt)
-                    
-                    context.logger.info("Token refreshed successfully")
-                } catch {
-                    context.logger.error("Token refresh failed: \(error)")
-                    // Clear invalid tokens
-                    context.sessions.clearAll()
-                    throw HTTPError(.unauthorized, reason: "Token refresh failed")
-                }
-            }
-        }
-        
-        return try await next(request, context)
+    protected.get("api/user") { request, context async throws -> UserSession in
+        try context.requireIdentity()
     }
 }
 ```
 
 ## Environment Configuration
 
-Set up your environment variables:
+Hummingbird ships a built-in `Environment` type that reads process environment
+variables and can merge in a `.env` file. Keys are **lowercased** automatically,
+and `require(_:)` throws `Environment.Error` (instead of calling `fatalError`):
 
 ```swift
-enum Environment {
-    static func get(_ key: String) -> String? {
-        ProcessInfo.processInfo.environment[key]
-    }
-    
-    static func require(_ key: String) -> String {
-        guard let value = get(key) else {
-            fatalError("Missing required environment variable: \(key)")
-        }
-        return value
-    }
-}
+// Read process env merged with .env file (async because of file I/O).
+let env = try await Environment().merging(with: Environment.dotEnv(".env"))
+
+// Access optionally:
+let id = env.get("google_client_id")
+
+// Access required (throws if missing):
+let secret = try env.require("google_client_secret")
 ```
 
-Create a `.env` file or set environment variables:
-
 ```bash
-# Google OAuth2
+# .env (never commit this file)
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_REDIRECT_URI=http://localhost:8080/auth/google/callback
 
-# Microsoft OAuth2
 MICROSOFT_CLIENT_ID=your-microsoft-client-id
 MICROSOFT_CLIENT_SECRET=your-microsoft-client-secret
 MICROSOFT_REDIRECT_URI=http://localhost:8080/auth/microsoft/callback
 
-# GitHub OAuth2
 GITHUB_CLIENT_ID=your-github-client-id
 GITHUB_CLIENT_SECRET=your-github-client-secret
 GITHUB_REDIRECT_URI=http://localhost:8080/auth/github/callback
-
-# Discord OAuth2
-DISCORD_CLIENT_ID=your-discord-client-id
-DISCORD_CLIENT_SECRET=your-discord-client-secret
-DISCORD_REDIRECT_URI=http://localhost:8080/auth/discord/callback
 ```
 
-## Complete Application Example
+## Token Refresh
 
-Here's a complete working application:
+Refresh expired access tokens in a middleware:
 
 ```swift
-import ArgumentParser
-import Hummingbird
-import HummingbirdAuth
-import OAuthKit
+struct TokenRefreshMiddleware<Context: SessionRequestContext>: RouterMiddleware
+where Context.Session == UserSession {
 
-@main
-struct OAuthApp: AsyncParsableCommand {
-    @Option(name: .shortAndLong)
-    var hostname: String = "127.0.0.1"
+    let oauthKit: OAuthClientFactory
+    /// OAuth credentials injected at init time — Environment can't be awaited
+    /// inside a middleware `handle` call, so pass values in up front.
+    let clientID: String
+    let clientSecret: String
+    let redirectURI: String
 
-    @Option(name: .shortAndLong)
-    var port: Int = 8080
-
-    func run() async throws {
-        let app = try await buildApplication(
-            configuration: .init(
-                address: .hostname(self.hostname, port: self.port),
-                serverName: "OAuthApp"
-            )
-        )
-        try await app.runService()
+    func handle(
+        _ request: Request,
+        context: Context,
+        next: (Request, Context) async throws -> Response
+    ) async throws -> Response {
+        // Only refresh if there is an active session with a refresh token.
+        if var session = context.sessions.session,
+           let refreshToken = session.refreshToken {
+            do {
+                // Build the provider using the credentials injected at init time.
+                let googleProvider = try await oauthKit.googleProvider(
+                    clientID: clientID,
+                    clientSecret: clientSecret,
+                    redirectURI: redirectURI
+                )
+                let newTokens = try await googleProvider.refreshAccessToken(
+                    refreshToken: refreshToken
+                )
+                session = UserSession(
+                    id: session.id,
+                    name: session.name,
+                    email: session.email,
+                    accessToken: newTokens.accessToken,
+                    refreshToken: newTokens.refreshToken ?? session.refreshToken,
+                    idToken: newTokens.idToken ?? session.idToken,
+                    provider: session.provider
+                )
+                context.sessions.setSession(session, expiresIn: .minutes(30))
+            } catch {
+                context.logger.warning("Token refresh failed: \(error)")
+            }
+        }
+        return try await next(request, context)
     }
-}
-
-func buildApplication(configuration: ApplicationConfiguration) async throws -> some ApplicationProtocol {
-    let router = Router(context: AppRequestContext.self)
-    
-    let oauthFactory = OAuthClientFactory()
-    let sessionStorage = MemorySessionStorage<String, User>(expiration: .minutes(30))
-    
-    // Middleware
-    router.addMiddleware {
-        LogRequestsMiddleware(.info)
-        CORSMiddleware()
-        SessionMiddleware(storage: sessionStorage)
-        TokenRefreshMiddleware()
-    }
-    
-    // Routes
-    router.get("/") { _, _ in
-        """
-        <h1>OAuth with Hummingbird</h1>
-        <a href="/auth/google">Login with Google</a><br>
-        <a href="/auth/microsoft">Login with Microsoft</a><br>
-        <a href="/auth/github">Login with GitHub</a><br>
-        <a href="/auth/discord">Login with Discord</a>
-        """
-    }
-    
-    // Configure OAuth routes
-    try await configureOAuthRoutes(router, oauthFactory: oauthFactory)
-    configureProtectedRoutes(router)
-    
-    var application = Application(
-        router: router,
-        server: .http1(),
-        configuration: configuration
-    )
-    
-    application.addServices(oauthFactory, sessionStorage)
-    return application
 }
 ```
 
-## API Integration
+## Error Handling
 
-Make authenticated API calls using stored tokens:
+Map `OAuth2Error` to HTTP responses:
 
 ```swift
-func fetchUserProfile(accessToken: String) async throws -> [String: String] {
-    let httpClient = HTTPClient.shared
-    
-    var request = HTTPClientRequest(url: "https://api.example.com/user")
-    request.headers.add(name: "Authorization", value: "Bearer \(accessToken)")
-    
-    let response = try await httpClient.execute(request, timeout: .seconds(30))
-    
-    guard response.status == .ok else {
-        throw HTTPError(.badGateway, reason: "API request failed")
+extension OAuth2Error: HTTPResponseError {
+    public var status: HTTPResponse.Status {
+        switch self {
+        case .configurationError:   return .internalServerError
+        case .networkError:         return .badGateway
+        case .responseError,
+             .invalidResponse:      return .badRequest
+        case .tokenError:           return .unauthorized
+        default:                    return .internalServerError
+        }
     }
-    
-    let data = try await response.body.collect(upTo: 1024 * 1024)
-    return try JSONDecoder().decode([String: String].self, from: data)
+
+    public var headers: HTTPFields { [:] }
 }
 ```
 
 ## Security Best Practices
 
-1. **Session Security**: Use secure session storage in production (Redis, database)
-2. **HTTPS**: Always use HTTPS in production environments
-3. **State Validation**: Always validate the state parameter to prevent CSRF
-4. **Token Storage**: Store tokens securely and implement proper expiration
-5. **Error Handling**: Don't expose sensitive information in error messages
-6. **CORS**: Configure CORS properly for your domain
-
-## Production Considerations
-
-### Session Storage
-
-For production, use persistent session storage:
-
-```swift
-// Redis session storage
-let redisService = RedisService(url: "redis://localhost:6379")
-let sessionStorage = RedisSessionStorage<String, User>(
-    redis: redisService,
-    expiration: .minutes(30)
-)
-
-// Database session storage
-let fluentSessionStorage = FluentSessionStorage<String, User>(
-    fluent: fluent,
-    expiration: .minutes(30)
-)
-```
-
-### Error Handling
-
-Implement proper OAuth error handling:
-
-```swift
-extension OAuth2Error: HTTPResponseError {
-    public var status: HTTPResponseStatus {
-        switch self {
-        case .configurationError:
-            return .internalServerError
-        case .networkError:
-            return .badGateway
-        case .responseError, .invalidResponse:
-            return .badRequest
-        case .tokenValidationError:
-            return .unauthorized
-        default:
-            return .internalServerError
-        }
-    }
-    
-    public var headers: HTTPFields {
-        return [:]
-    }
-}
-```
+1. **HTTPS only** — never serve OAuth callbacks over plain HTTP in production
+2. **State validation** — always verify the `state` parameter to prevent CSRF; the `pendingHandshakes` dictionary above provides this
+3. **Short-lived handshake store** — expire entries in `pendingHandshakes` after ~10 minutes to avoid memory leaks
+4. **Persistent sessions** — replace `MemoryPersistDriver` with a Redis-backed driver in production so sessions survive restarts
+5. **Secure cookies** — configure `SessionCookieParameters` with `secure: true` and `sameSite: .strict` in production
+6. **Never log tokens** — access and refresh tokens are credentials; keep them out of log output

--- a/Sources/OAuthKit/OAuthKit.docc/HummingbirdIntegration.md
+++ b/Sources/OAuthKit/OAuthKit.docc/HummingbirdIntegration.md
@@ -1,14 +1,15 @@
 # Hummingbird Integration
 
-Integrate OAuthKit with Hummingbird 2 using `HummingbirdAuth` for session management.
+Integrate OAuthKit with Hummingbird 2 using `HummingbirdAuth` for session management and `swift-configuration` for credential configuration.
 
 ## Overview
 
 This guide shows how to add OAuth2 sign-in to a Hummingbird 2 application. It uses:
 
 - **OAuthKit** for OAuth provider communication
-- **HummingbirdAuth** for session middleware, authenticator middleware, and request context protocols
-- **ServiceLifecycle** to wire services (OAuthKit's `OAuthClientFactory` is itself a `Service`)
+- **HummingbirdAuth** for session middleware and request context protocols
+- **swift-configuration** for reading credentials from environment variables and `.env` files
+- **ServiceLifecycle** — `OAuthClientFactory` is a `Service`; JWKS keys stay fresh automatically
 
 ## Installation
 
@@ -18,11 +19,13 @@ dependencies: [
     .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
     .package(url: "https://github.com/hummingbird-project/hummingbird-auth.git", from: "2.0.0"),
     .package(url: "https://github.com/thoven87/oauth-kit.git", from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-configuration.git", from: "1.0.0"),
 ],
 targets: [
     .executableTarget(
         name: "App",
         dependencies: [
+            .product(name: "Configuration", package: "swift-configuration"),
             .product(name: "Hummingbird", package: "hummingbird"),
             .product(name: "HummingbirdAuth", package: "hummingbird-auth"),
             .product(name: "OAuthKit", package: "oauth-kit"),
@@ -31,128 +34,184 @@ targets: [
 ]
 ```
 
-## Session Model
+## Request Context and Session Model
 
-`HummingbirdAuth`'s sessions store **one typed value** per request. Define a `UserSession` struct that holds everything you want to persist across requests:
-
-```swift
-import HummingbirdAuth
-import OAuthKit
-
-/// The authenticated user stored in the session.
-/// `Sendable` (not `Authenticatable`) — the old HB1 protocol is removed.
-struct UserSession: Codable, Sendable {
-    let id: String
-    let name: String
-    let email: String
-    let accessToken: String
-    let refreshToken: String?
-    /// Raw ID token — needed to build the provider end-session URL on logout.
-    let idToken: String?
-    /// Which provider authenticated this user ("google", "microsoft", etc.).
-    let provider: String
-}
-
-/// Short-lived OAuth handshake data stored separately (e.g. a signed cookie
-/// or an in-process Mutex dictionary) — NOT in the user session.
-struct OAuthHandshake: Sendable {
-    let state: String
-    let codeVerifier: String?
-    let provider: String
-}
-
-/// Request context: session key = String (cookie value), identity = UserSession.
-typealias AppRequestContext = BasicSessionRequestContext<String, UserSession>
-```
-
-> **Why a separate `OAuthHandshake`?** Sessions in HummingbirdAuth store one value; a dictionary-style API does not exist. Short-lived OAuth state (the `state` and `code_verifier` parameters) should live outside the session — for example in a signed cookie or in a server-side `Mutex`-protected dictionary that is cleaned up after the callback.
-
-## Application Setup
+Model the session as a typed enum nested inside `AppRequestContext`. A session is either
+in-progress (handshake) or authenticated — never both:
 
 ```swift
 import Hummingbird
 import HummingbirdAuth
+
+struct AppRequestContext: SessionRequestContext, RequestContext {
+
+    enum Session: Sendable, Codable {
+
+        /// Short-lived OAuth state — valid only during the redirect/callback round-trip.
+        struct OAuthHandshake: Sendable, Codable {
+            let state: String
+            let codeVerifier: String?
+            let provider: String
+        }
+
+        /// Persistent user identity after authentication succeeds.
+        struct AuthenticatedUser: Sendable, Codable {
+            let id: String
+            let name: String
+            let email: String
+            let accessToken: String
+            let refreshToken: String?
+            /// Raw ID token — needed to build the provider end-session URL on logout.
+            let idToken: String?
+            /// Which provider authenticated this user ("google", "microsoft", etc.).
+            let provider: String
+        }
+
+        case handshake(OAuthHandshake)
+        case authenticated(AuthenticatedUser)
+
+        var handshake: OAuthHandshake? {
+            guard case .handshake(let h) = self else { return nil }
+            return h
+        }
+
+        var authenticatedUser: AuthenticatedUser? {
+            guard case .authenticated(let u) = self else { return nil }
+            return u
+        }
+    }
+
+    let sessions: SessionContext<Session>
+    var coreContext: CoreRequestContextStorage
+
+    init(source: ApplicationRequestContextSource) {
+        sessions = .init()
+        coreContext = .init(source: source)
+    }
+}
+```
+
+> **Why an enum?** `HummingbirdAuth` sessions store one typed value per cookie.
+> Modelling the two possible states as cases makes illegal combinations impossible —
+> a session in the handshake phase can't accidentally carry user data, and vice versa.
+> It also means the OAuth `state` parameter is stored per-session, so there is no
+> need for a global `Mutex` dictionary.
+
+## Configuration
+
+`swift-configuration` provides a `ConfigReader` that reads from command-line arguments,
+environment variables, a `.env` file, and in-memory defaults — in priority order:
+
+```swift
+import Configuration
+import Hummingbird
+
+@main struct App {
+    static func main() async throws {
+        // Sources are queried in the order listed; first non-nil value wins.
+        let reader = try await ConfigReader(providers: [
+            CommandLineArgumentsProvider(),
+            EnvironmentVariablesProvider(),
+            EnvironmentVariablesProvider(environmentFilePath: ".env", allowMissing: true),
+            InMemoryProvider(values: [
+                "http.serverName": "my-app",
+            ])
+        ])
+        let app = try await buildApplication(reader: reader)
+        try await app.runService()
+    }
+}
+```
+
+`EnvironmentVariablesProvider` maps key components to environment variable names
+automatically: `google.client_id` → `GOOGLE_CLIENT_ID`, `microsoft.redirect_uri` →
+`MICROSOFT_REDIRECT_URI`. Scoped readers and env vars compose naturally:
+
+```swift
+let googleCfg = reader.scoped(to: "google")
+let clientID  = googleCfg.string(forKey: "client_id")  // reads GOOGLE_CLIENT_ID
+```
+
+## Application Setup
+
+Pass `oauthKit` directly to `Application` via `services:` — no external `ServiceGroup`
+is required. `app.runService()` manages the HTTP server and all registered services together:
+
+```swift
+import Configuration
+import Hummingbird
+import HummingbirdAuth
+import Logging
 import OAuthKit
-import ServiceLifecycle
-import Synchronization
 
-// In-process store for pending OAuth handshakes, keyed by `state` parameter.
-// Replace with Redis or a database in production.
-let pendingHandshakes: Mutex<[String: OAuthHandshake]> = Mutex([:])
-
-func buildApplication() async throws -> some ApplicationProtocol {
-    // Hummingbird's built-in Environment merges process env with a .env file.
-    // Keys are lowercased automatically; require(_:) throws instead of crashing.
-    let env = try await Environment().merging(with: Environment.dotEnv(".env"))
-    let oauthKit = OAuthClientFactory()
+func buildApplication(reader: ConfigReader) async throws -> some ApplicationProtocol {
+    let logger = Logger(label: "app")
+    let oauthKit = OAuthClientFactory(logger: logger)
     let persist = MemoryPersistDriver()
-    let sessionStorage = SessionStorage<UserSession>(persist)
 
     let router = Router(context: AppRequestContext.self)
     router.addMiddleware {
         LogRequestsMiddleware(.info)
-        SessionMiddleware(storage: sessionStorage)
+        SessionMiddleware(storage: persist)
     }
 
-    configureOAuthRoutes(router, oauthKit: oauthKit)
+    configureOAuthRoutes(router, reader: reader, oauthKit: oauthKit)
     configureProtectedRoutes(router)
 
-    let app = Application(router: router, configuration: .init(address: .hostname("127.0.0.1", port: 8080)))
-
-    // OAuthClientFactory is a Service — add it to the ServiceGroup so JWKS
-    // keys are kept refreshed automatically.
-    return ServiceGroup(
-        configuration: .init(
-            services: [oauthKit, app],
-            gracefulShutdownSignals: [.sigterm, .sigint],
-            logger: Logger(label: "app")
-        )
+    // oauthKit is a Service — adding it via `services:` keeps JWKS keys refreshed
+    // automatically alongside the HTTP server.
+    return Application(
+        router: router,
+        configuration: ApplicationConfiguration(reader: reader.scoped(to: "http")),
+        services: [oauthKit],
+        logger: logger
     )
 }
 ```
 
 ## OAuth Routes
 
-### Initiating the flow
+Because OAuth handshake state is stored in the session cookie, no global `Mutex` dictionary
+is needed. Each browser tab has its own session and therefore its own isolated OAuth state.
 
 ```swift
 func configureOAuthRoutes(
     _ router: Router<AppRequestContext>,
+    reader: ConfigReader,
     oauthKit: OAuthClientFactory
 ) {
     // Step 1 — redirect the browser to the provider.
     router.get("auth/:provider") { request, context async throws -> Response in
-        let providerName = try context.parameters.require("provider")
-
+        let provider = try context.parameters.require("provider")
         let state = UUID().uuidString
+
         let (authURL, codeVerifier) = try await makeAuthURL(
-            provider: providerName,
+            provider: provider,
             state: state,
+            reader: reader,
             oauthKit: oauthKit
         )
 
-        // Store the handshake state until the callback arrives.
-        pendingHandshakes.withLock {
-            $0[state] = OAuthHandshake(
-                state: state,
-                codeVerifier: codeVerifier,
-                provider: providerName
-            )
-        }
+        // Store the handshake in the session — replaces any previous state.
+        context.sessions.setSession(.handshake(.init(
+            state: state,
+            codeVerifier: codeVerifier,
+            provider: provider
+        )))
 
-        return Response(status: .seeOther, headers: [.location: authURL.absoluteString])
+        return .redirect(to: authURL.absoluteString, type: .normal)
     }
 
     // Step 2 — handle the provider callback.
     router.get("auth/:provider/callback") { request, context async throws -> Response in
         let queryParams = request.uri.queryParameters
 
-        guard let receivedState = queryParams.get("state"),
-              let handshake = pendingHandshakes.withLock({ $0.removeValue(forKey: receivedState) })
-        else {
+        guard let handshake = context.sessions.session?.handshake else {
+            throw HTTPError(.badRequest, message: "No OAuth session in progress")
+        }
+        guard handshake.state == queryParams.get("state") else {
             throw HTTPError(.badRequest, message: "Invalid or expired state parameter")
         }
-
         guard let code = queryParams.get("code") else {
             throw HTTPError(.badRequest, message: "Authorization code required")
         }
@@ -161,10 +220,11 @@ func configureOAuthRoutes(
             provider: handshake.provider,
             code: code,
             codeVerifier: handshake.codeVerifier,
+            reader: reader,
             oauthKit: oauthKit
         )
 
-        let session = UserSession(
+        context.sessions.setSession(.authenticated(.init(
             id: claims?.sub?.value ?? UUID().uuidString,
             name: claims?.name ?? "Unknown",
             email: claims?.email ?? "",
@@ -172,38 +232,29 @@ func configureOAuthRoutes(
             refreshToken: tokenResponse.refreshToken,
             idToken: tokenResponse.idToken,
             provider: handshake.provider
-        )
+        )))
 
-        // Store the user session — one typed value, no dictionary.
-        context.sessions.setSession(session, expiresIn: .minutes(30))
-
-        return Response(status: .seeOther, headers: [.location: "/dashboard"])
+        return .redirect(to: "/dashboard", type: .normal)
     }
 
-    // Logout — two layers:
-    // 1. Clear the local session (always).
-    // 2. Redirect to the provider's end-session endpoint if available (SSO logout),
-    //    so the provider also invalidates the session on its side.
+    // Logout — clear the local session, then optionally redirect to the provider's
+    // end-session endpoint (SSO logout) if the provider supports it.
     router.post("logout") { request, context async throws -> Response in
-        let session = context.sessions.session
+        let user = context.sessions.session?.authenticatedUser
         context.sessions.clearSession()
 
-        // If we stored an ID token, build the provider end-session URL.
-        // endSessionURL uses the OIDC discovery `end_session_endpoint`;
-        // not all providers support this (GitHub doesn't, Google/Microsoft do).
-        if let idToken = session?.idToken,
-           let providerName = session?.provider {
-            if let endSessionURL = try? await makeEndSessionURL(
-                provider: providerName,
+        if let user, let idToken = user.idToken,
+           let endURL = try? await makeEndSessionURL(
+                provider: user.provider,
                 idToken: idToken,
                 postLogoutRedirectURI: "http://localhost:8080/",
+                reader: reader,
                 oauthKit: oauthKit
-            ) {
-                return Response(status: .seeOther, headers: [.location: endSessionURL.absoluteString])
-            }
+           ) {
+            return .redirect(to: endURL.absoluteString, type: .normal)
         }
 
-        return Response(status: .seeOther, headers: [.location: "/"])
+        return .redirect(to: "/", type: .normal)
     }
 }
 ```
@@ -211,23 +262,32 @@ func configureOAuthRoutes(
 ### Provider helpers
 
 ```swift
-/// Build the provider end-session (SSO logout) URL.
-/// Only OIDC providers that advertise `end_session_endpoint` in their
-/// discovery document support this — GitHub and other OAuth-only providers
-/// do not. Falls back to `nil` so the caller can skip the redirect.
+/// A small extension so missing config keys throw instead of returning nil.
+private extension ConfigReader {
+    func require(_ key: String) throws -> String {
+        guard let value = string(forKey: key), !value.isEmpty else {
+            throw OAuth2Error.configurationError("Missing required configuration key: '\(key)'")
+        }
+        return value
+    }
+}
+
+/// Build the end-session (SSO logout) URL.
+/// Returns `nil` for providers that don't advertise `end_session_endpoint` (e.g. GitHub).
 func makeEndSessionURL(
     provider: String,
     idToken: String,
     postLogoutRedirectURI: String,
+    reader: ConfigReader,
     oauthKit: OAuthClientFactory
 ) async throws -> URL? {
-    let env = try await Environment().merging(with: Environment.dotEnv(".env"))
     switch provider.lowercased() {
     case "google":
+        let cfg = reader.scoped(to: "google")
         let p = try await oauthKit.googleProvider(
-            clientID: try env.require("google_client_id"),
-            clientSecret: try env.require("google_client_secret"),
-            redirectURI: try env.require("google_redirect_uri")
+            clientID: try cfg.require("client_id"),
+            clientSecret: try cfg.require("client_secret"),
+            redirectURI: try cfg.require("redirect_uri")
         )
         return try? p.revokeToken(
             idToken: idToken,
@@ -235,10 +295,11 @@ func makeEndSessionURL(
             state: nil
         )
     case "microsoft":
+        let cfg = reader.scoped(to: "microsoft")
         let p = try await oauthKit.microsoftProvider(
-            clientID: try env.require("microsoft_client_id"),
-            clientSecret: try env.require("microsoft_client_secret"),
-            redirectURI: try env.require("microsoft_redirect_uri"),
+            clientID: try cfg.require("client_id"),
+            clientSecret: try cfg.require("client_secret"),
+            redirectURI: try cfg.require("redirect_uri"),
             tenantKind: .common
         )
         return try? p.endSessionURL(
@@ -246,25 +307,23 @@ func makeEndSessionURL(
             postLogoutRedirectURI: postLogoutRedirectURI
         )
     default:
-        return nil  // provider doesn't support end-session
+        return nil
     }
 }
 
 func makeAuthURL(
     provider: String,
     state: String,
+    reader: ConfigReader,
     oauthKit: OAuthClientFactory
 ) async throws -> (URL, String?) {
-    // Environment is Hummingbird's built-in type.
-    // Keys are lowercased; require(_:) throws Environment.Error if missing.
-    let env = try await Environment().merging(with: Environment.dotEnv(".env"))
-
     switch provider.lowercased() {
     case "google":
+        let cfg = reader.scoped(to: "google")
         let p = try await oauthKit.googleProvider(
-            clientID: try env.require("google_client_id"),
-            clientSecret: try env.require("google_client_secret"),
-            redirectURI: try env.require("google_redirect_uri")
+            clientID: try cfg.require("client_id"),
+            clientSecret: try cfg.require("client_secret"),
+            redirectURI: try cfg.require("redirect_uri")
         )
         let (url, verifier) = try p.generateAuthURL(
             state: state,
@@ -273,10 +332,11 @@ func makeAuthURL(
         return (url, verifier)
 
     case "microsoft":
+        let cfg = reader.scoped(to: "microsoft")
         let p = try await oauthKit.microsoftProvider(
-            clientID: try env.require("microsoft_client_id"),
-            clientSecret: try env.require("microsoft_client_secret"),
-            redirectURI: try env.require("microsoft_redirect_uri"),
+            clientID: try cfg.require("client_id"),
+            clientSecret: try cfg.require("client_secret"),
+            redirectURI: try cfg.require("redirect_uri"),
             tenantKind: .common
         )
         let (url, verifier) = try p.generateAuthorizationURL(
@@ -286,10 +346,11 @@ func makeAuthURL(
         return (url, verifier)
 
     case "github":
+        let cfg = reader.scoped(to: "github")
         let p = oauthKit.githubProvider(
-            clientID: try env.require("github_client_id"),
-            clientSecret: try env.require("github_client_secret"),
-            redirectURI: try env.require("github_redirect_uri")
+            clientID: try cfg.require("client_id"),
+            clientSecret: try cfg.require("client_secret"),
+            redirectURI: try cfg.require("redirect_uri")
         )
         let (url, verifier) = try p.signInURL(
             state: state,
@@ -306,16 +367,16 @@ func exchangeCode(
     provider: String,
     code: String,
     codeVerifier: String?,
+    reader: ConfigReader,
     oauthKit: OAuthClientFactory
 ) async throws -> (TokenResponse, IDTokenClaims?) {
-    let env = try await Environment().merging(with: Environment.dotEnv(".env"))
-
     switch provider.lowercased() {
     case "google":
+        let cfg = reader.scoped(to: "google")
         let p = try await oauthKit.googleProvider(
-            clientID: try env.require("google_client_id"),
-            clientSecret: try env.require("google_client_secret"),
-            redirectURI: try env.require("google_redirect_uri")
+            clientID: try cfg.require("client_id"),
+            clientSecret: try cfg.require("client_secret"),
+            redirectURI: try cfg.require("redirect_uri")
         )
         let (tokenResponse, claims) = try await p.exchangeCode(
             code: code, codeVerifier: codeVerifier
@@ -323,10 +384,11 @@ func exchangeCode(
         return (tokenResponse, claims)
 
     case "microsoft":
+        let cfg = reader.scoped(to: "microsoft")
         let p = try await oauthKit.microsoftProvider(
-            clientID: try env.require("microsoft_client_id"),
-            clientSecret: try env.require("microsoft_client_secret"),
-            redirectURI: try env.require("microsoft_redirect_uri"),
+            clientID: try cfg.require("client_id"),
+            clientSecret: try cfg.require("client_secret"),
+            redirectURI: try cfg.require("redirect_uri"),
             tenantKind: .common
         )
         let (tokenResponse, claims) = try await p.exchangeCode(
@@ -335,10 +397,11 @@ func exchangeCode(
         return (tokenResponse, claims)
 
     case "github":
+        let cfg = reader.scoped(to: "github")
         let p = oauthKit.githubProvider(
-            clientID: try env.require("github_client_id"),
-            clientSecret: try env.require("github_client_secret"),
-            redirectURI: try env.require("github_redirect_uri")
+            clientID: try cfg.require("client_id"),
+            clientSecret: try cfg.require("client_secret"),
+            redirectURI: try cfg.require("redirect_uri")
         )
         let tokenResponse = try await p.exchangeCode(
             code: code, codeVerifier: codeVerifier
@@ -353,51 +416,36 @@ func exchangeCode(
 
 ## Protected Routes
 
-Use `SessionAuthenticator` to restore the user from the session on each request:
+Check the session's `authenticatedUser` to guard routes:
 
 ```swift
 func configureProtectedRoutes(_ router: Router<AppRequestContext>) {
-    let protected = router.group()
-        .add(middleware: SessionAuthenticator { (id: String, context) async throws -> UserSession? in
-            // Load from your database using `id` (the session cookie value).
-            // In this example we return the session value stored by setSession(_:).
-            return context.sessions.session
-        })
-        .add(middleware: IsAuthenticatedMiddleware<AppRequestContext>())
-
-    protected.get("dashboard") { request, context async throws -> Response in
-        let user = try context.requireIdentity()
+    router.group("dashboard").get { request, context async throws -> Response in
+        guard let user = context.sessions.session?.authenticatedUser else {
+            return .redirect(to: "/", type: .normal)
+        }
         return Response(
             status: .ok,
             body: .init(byteBuffer: .init(string: "Welcome, \(user.name)!"))
         )
     }
 
-    protected.get("api/user") { request, context async throws -> UserSession in
-        try context.requireIdentity()
+    router.group("api").get("user") { request, context async throws -> AppRequestContext.Session.AuthenticatedUser in
+        guard let user = context.sessions.session?.authenticatedUser else {
+            throw HTTPError(.unauthorized)
+        }
+        return user
     }
 }
 ```
 
 ## Environment Configuration
 
-Hummingbird ships a built-in `Environment` type that reads process environment
-variables and can merge in a `.env` file. Keys are **lowercased** automatically,
-and `require(_:)` throws `Environment.Error` (instead of calling `fatalError`):
-
-```swift
-// Read process env merged with .env file (async because of file I/O).
-let env = try await Environment().merging(with: Environment.dotEnv(".env"))
-
-// Access optionally:
-let id = env.get("google_client_id")
-
-// Access required (throws if missing):
-let secret = try env.require("google_client_secret")
-```
+`EnvironmentVariablesProvider` converts dot-separated config keys to uppercase environment
+variable names. The `.env` file uses the same names:
 
 ```bash
-# .env (never commit this file)
+# .env — never commit this file
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_REDIRECT_URI=http://localhost:8080/auth/google/callback
@@ -409,51 +457,49 @@ MICROSOFT_REDIRECT_URI=http://localhost:8080/auth/microsoft/callback
 GITHUB_CLIENT_ID=your-github-client-id
 GITHUB_CLIENT_SECRET=your-github-client-secret
 GITHUB_REDIRECT_URI=http://localhost:8080/auth/github/callback
+
+# Hummingbird HTTP server
+HTTP_HOST=0.0.0.0
+HTTP_PORT=8080
 ```
 
 ## Token Refresh
 
-Refresh expired access tokens in a middleware:
+Refresh expired access tokens in a middleware. Inject the scoped `ConfigReader` at
+initialisation time — `ConfigReader` is `Sendable` so it is safe to store:
 
 ```swift
-struct TokenRefreshMiddleware<Context: SessionRequestContext>: RouterMiddleware
-where Context.Session == UserSession {
+struct TokenRefreshMiddleware: RouterMiddleware {
+    typealias Context = AppRequestContext
 
     let oauthKit: OAuthClientFactory
-    /// OAuth credentials injected at init time — Environment can't be awaited
-    /// inside a middleware `handle` call, so pass values in up front.
-    let clientID: String
-    let clientSecret: String
-    let redirectURI: String
+    /// Pre-scoped reader for the active provider's credentials.
+    let providerConfig: ConfigReader
 
     func handle(
         _ request: Request,
         context: Context,
         next: (Request, Context) async throws -> Response
     ) async throws -> Response {
-        // Only refresh if there is an active session with a refresh token.
-        if var session = context.sessions.session,
-           let refreshToken = session.refreshToken {
+        if var user = context.sessions.session?.authenticatedUser,
+           let refreshToken = user.refreshToken {
             do {
-                // Build the provider using the credentials injected at init time.
-                let googleProvider = try await oauthKit.googleProvider(
-                    clientID: clientID,
-                    clientSecret: clientSecret,
-                    redirectURI: redirectURI
+                let p = try await oauthKit.googleProvider(
+                    clientID: try providerConfig.require("client_id"),
+                    clientSecret: try providerConfig.require("client_secret"),
+                    redirectURI: try providerConfig.require("redirect_uri")
                 )
-                let newTokens = try await googleProvider.refreshAccessToken(
-                    refreshToken: refreshToken
-                )
-                session = UserSession(
-                    id: session.id,
-                    name: session.name,
-                    email: session.email,
+                let newTokens = try await p.refreshAccessToken(refreshToken: refreshToken)
+                user = AppRequestContext.Session.AuthenticatedUser(
+                    id: user.id,
+                    name: user.name,
+                    email: user.email,
                     accessToken: newTokens.accessToken,
-                    refreshToken: newTokens.refreshToken ?? session.refreshToken,
-                    idToken: newTokens.idToken ?? session.idToken,
-                    provider: session.provider
+                    refreshToken: newTokens.refreshToken ?? user.refreshToken,
+                    idToken: newTokens.idToken ?? user.idToken,
+                    provider: user.provider
                 )
-                context.sessions.setSession(session, expiresIn: .minutes(30))
+                context.sessions.setSession(.authenticated(user), expiresIn: .minutes(30))
             } catch {
                 context.logger.warning("Token refresh failed: \(error)")
             }
@@ -461,6 +507,16 @@ where Context.Session == UserSession {
         return try await next(request, context)
     }
 }
+```
+
+Wire it into a route group:
+
+```swift
+router.group()
+    .add(middleware: TokenRefreshMiddleware(
+        oauthKit: oauthKit,
+        providerConfig: reader.scoped(to: "google")
+    ))
 ```
 
 ## Error Handling
@@ -487,8 +543,8 @@ extension OAuth2Error: HTTPResponseError {
 ## Security Best Practices
 
 1. **HTTPS only** — never serve OAuth callbacks over plain HTTP in production
-2. **State validation** — always verify the `state` parameter to prevent CSRF; the `pendingHandshakes` dictionary above provides this
-3. **Short-lived handshake store** — expire entries in `pendingHandshakes` after ~10 minutes to avoid memory leaks
+2. **State validation** — the `state` parameter is stored in the session and checked on callback, preventing CSRF by design
+3. **Short session expiry** — set `defaultSessionExpiration` on `SessionMiddleware` and call `setSession(_:expiresIn:)` with an explicit TTL
 4. **Persistent sessions** — replace `MemoryPersistDriver` with a Redis-backed driver in production so sessions survive restarts
-5. **Secure cookies** — configure `SessionCookieParameters` with `secure: true` and `sameSite: .strict` in production
+5. **Secure cookies** — configure `SessionCookieParameters` with `secure: true` and `sameSite: .lax` in production. OAuth callbacks are top-level cross-site GET redirects; `sameSite: .strict` prevents the browser from sending the session cookie on the callback and breaks the flow
 6. **Never log tokens** — access and refresh tokens are credentials; keep them out of log output

--- a/Sources/OAuthKit/OAuthKit.docc/OAuthKit.md
+++ b/Sources/OAuthKit/OAuthKit.docc/OAuthKit.md
@@ -6,14 +6,6 @@ A comprehensive Swift OAuth2 and OpenID Connect client library with modern async
 
 OAuthKit is a powerful, type-safe OAuth2 and OpenID Connect client library built for modern Swift applications. It provides seamless integration with popular OAuth providers while maintaining full compatibility with any Swift server framework.
 
-### Recent Improvements
-
-**✅ API Consistency Fixed**: All OAuth providers now have a consistent `refreshAccessToken(refreshToken:)` method directly on the provider, eliminating the previous inconsistency where only Google had this convenience method while others required accessing `provider.client.refreshToken()`.
-
-**✅ Device Authorization Flow**: Full support for RFC 8628 Device Authorization Flow has been implemented, enabling authentication for input-constrained devices like smart TVs, IoT devices, CLI tools, and gaming consoles.
-
-**✅ Okta MFA Support**: Complete multi-factor authentication support for Okta, including push notifications with number challenges, SMS codes, TOTP tokens, and polling mechanisms for enterprise authentication workflows.
-
 ### Key Features
 
 - **OAuth 2.0 Authorization Code Flow** with PKCE support

--- a/Sources/OAuthKit/OAuthKit.docc/OktaMFA.md
+++ b/Sources/OAuthKit/OAuthKit.docc/OktaMFA.md
@@ -38,9 +38,9 @@ OAuthKit supports these Okta MFA factor types:
 import OAuthKit
 
 let provider = try await oauthFactory.oktaProvider(
+    domain: "your-tenant.okta.com",
     clientID: "your-okta-client-id",
     clientSecret: "your-okta-client-secret",
-    domain: "your-tenant.okta.com",
     redirectURI: "your-redirect-uri"
 )
 
@@ -322,9 +322,9 @@ struct OktaMFAApp {
         
         let factory = OAuthClientFactory()
         let provider = try await factory.oktaProvider(
+            domain: getEnvVar("OKTA_DOMAIN"),
             clientID: getEnvVar("OKTA_CLIENT_ID"),
             clientSecret: getEnvVar("OKTA_CLIENT_SECRET"),
-            domain: getEnvVar("OKTA_DOMAIN"),
             redirectURI: getEnvVar("OKTA_REDIRECT_URI")
         )
         

--- a/Sources/OAuthKit/OAuthKit.docc/OpenIDConnect.md
+++ b/Sources/OAuthKit/OAuthKit.docc/OpenIDConnect.md
@@ -27,13 +27,11 @@ OAuthKit provides a generic `OpenIDConnectClient` that can work with any OIDC-co
 import OAuthKit
 
 // Create client with automatic discovery
-let client = try await OpenIDConnectClient(
-    httpClient: HTTPClient.shared,
+let client = try await OAuthClientFactory().openIDConnectClient(
+    discoveryURL: "https://your-provider.com/.well-known/openid_configuration",
     clientID: "your-client-id",
     clientSecret: "your-client-secret",
-    discoveryURL: "https://your-provider.com/.well-known/openid_configuration",
-    redirectURI: "your-redirect-uri",
-    logger: Logger(label: "OIDC")
+    redirectURI: "your-redirect-uri"
 )
 
 // Or with manual configuration
@@ -59,7 +57,8 @@ let client = try await OpenIDConnectClient(
 
 ```swift
 // 1. Generate authorization URL
-let (authURL, codeVerifier) = try client.generateAuthorizationURL(
+let pkce = OAuth2Client.generatePKCE()
+let authURL = try client.generateAuthorizationURL(
     state: UUID().uuidString,
     scopes: ["openid", "profile", "email"]
 )
@@ -69,7 +68,7 @@ let (authURL, codeVerifier) = try client.generateAuthorizationURL(
 // 3. Exchange authorization code for tokens + claims
 let (tokenResponse, claims) = try await client.exchangeCode(
     code: authorizationCode,
-    codeVerifier: codeVerifier
+    codeVerifier: pkce.codeVerifier
 )
 
 // 4. Access user information from ID token claims
@@ -147,7 +146,7 @@ OpenID Connect defines standard scopes that determine which claims are included:
 
 ```swift
 // Request specific scopes
-let (authURL, codeVerifier) = try client.generateAuthorizationURL(
+let authURL = try client.generateAuthorizationURL(
     state: "state",
     scopes: ["openid", "profile", "email", "address", "phone"]
 )
@@ -230,16 +229,17 @@ let currentEmail = updatedClaims?.email
 // Generate nonce for enhanced security
 let nonce = UUID().uuidString
 
-let (authURL, codeVerifier) = try client.generateAuthorizationURL(
+let pkce = OAuth2Client.generatePKCE()
+let authURL = try client.generateAuthorizationURL(
     state: "state",
     additionalParameters: ["nonce": nonce],
     scopes: ["openid", "profile", "email"]
 )
 
 // After token exchange, verify nonce matches
-let (tokens, claims) = try await client.exchangeCode(code: code, codeVerifier: codeVerifier)
+let (tokens, claims) = try await client.exchangeCode(code: code, codeVerifier: pkce.codeVerifier)
 guard claims.nonce == nonce else {
-    throw OAuth2Error.tokenValidationError("Nonce mismatch - possible replay attack")
+    throw OAuth2Error.tokenError("Nonce mismatch - possible replay attack")
 }
 ```
 
@@ -248,7 +248,7 @@ guard claims.nonce == nonce else {
 ```swift
 // Always use state parameter to prevent CSRF attacks
 let state = UUID().uuidString
-let (authURL, codeVerifier) = try client.generateAuthorizationURL(
+let authURL = try client.generateAuthorizationURL(
     state: state,
     scopes: ["openid", "profile", "email"]
 )
@@ -262,7 +262,7 @@ let (authURL, codeVerifier) = try client.generateAuthorizationURL(
 do {
     let (tokens, claims) = try await client.exchangeCode(code: code, codeVerifier: codeVerifier)
     // Use validated claims
-} catch OAuth2Error.tokenValidationError(let message) {
+} catch OAuth2Error.tokenError(let message) {
     // ID token validation failed
     print("Token validation failed: \(message)")
 } catch OAuth2Error.jwksError(let message) {
@@ -283,17 +283,15 @@ The `OpenIDConnectClient` works with any compliant OpenID Connect provider:
 
 ```swift
 // Generic provider setup
-let client = try await OpenIDConnectClient(
-    httpClient: HTTPClient.shared,
+let client = try await OAuthClientFactory().openIDConnectClient(
+    discoveryURL: "https://any-oidc-provider.com/.well-known/openid_configuration",
     clientID: "your-client-id",
     clientSecret: "your-client-secret",
-    discoveryURL: "https://any-oidc-provider.com/.well-known/openid_configuration",
-    redirectURI: "your-redirect-uri",
-    logger: Logger(label: "OIDC")
+    redirectURI: "your-redirect-uri"
 )
 
 // Standard OIDC flow works the same regardless of provider
-let (authURL, codeVerifier) = try client.generateAuthorizationURL(
+let authURL = try client.generateAuthorizationURL(
     state: "state",
     scopes: ["openid", "profile", "email"]
 )

--- a/Sources/OAuthKit/OAuthKit.docc/RefreshTokenSupport.md
+++ b/Sources/OAuthKit/OAuthKit.docc/RefreshTokenSupport.md
@@ -264,9 +264,10 @@ func refreshTokenForProvider(
 ## Automatic Token Refresh
 
 Here's a Hummingbird 2 middleware that automatically refreshes tokens before they expire.
-See <doc:HummingbirdIntegration> for the full session and context setup.
+See <doc:HummingbirdIntegration> for the full session model and context setup.
 
 ```swift
+import Configuration
 import Hummingbird
 import HummingbirdAuth
 import OAuthKit
@@ -274,42 +275,41 @@ import OAuthKit
 /// Refreshes an expired Google access token before the request reaches
 /// downstream route handlers.
 ///
-/// Inject credentials via the initializer — `Environment` can't be awaited
-/// inside `handle`, so resolve configuration at application startup instead.
-struct TokenRefreshMiddleware<Context: SessionRequestContext>: RouterMiddleware
-where Context.Session == UserSession {
+/// `ConfigReader` is `Sendable` — storing a pre-scoped reader in the middleware
+/// avoids resolving credentials on every request.
+struct TokenRefreshMiddleware: RouterMiddleware {
+    typealias Context = AppRequestContext
 
     let oauthKit: OAuthClientFactory
-    let clientID: String
-    let clientSecret: String
-    let redirectURI: String
+    /// Pre-scoped reader for the active provider's credentials.
+    let providerConfig: ConfigReader
 
     func handle(
         _ request: Request,
         context: Context,
         next: (Request, Context) async throws -> Response
     ) async throws -> Response {
-        if var session = context.sessions.session,
-           let refreshToken = session.refreshToken {
+        if var user = context.sessions.session?.authenticatedUser,
+           let refreshToken = user.refreshToken {
             do {
                 let provider = try await oauthKit.googleProvider(
-                    clientID: clientID,
-                    clientSecret: clientSecret,
-                    redirectURI: redirectURI
+                    clientID: try providerConfig.require("client_id"),
+                    clientSecret: try providerConfig.require("client_secret"),
+                    redirectURI: try providerConfig.require("redirect_uri")
                 )
                 let newTokens = try await provider.refreshAccessToken(
                     refreshToken: refreshToken
                 )
-                session = UserSession(
-                    id: session.id,
-                    name: session.name,
-                    email: session.email,
+                user = AppRequestContext.Session.AuthenticatedUser(
+                    id: user.id,
+                    name: user.name,
+                    email: user.email,
                     accessToken: newTokens.accessToken,
-                    refreshToken: newTokens.refreshToken ?? session.refreshToken,
-                    idToken: newTokens.idToken ?? session.idToken,
-                    provider: session.provider
+                    refreshToken: newTokens.refreshToken ?? user.refreshToken,
+                    idToken: newTokens.idToken ?? user.idToken,
+                    provider: user.provider
                 )
-                context.sessions.setSession(session, expiresIn: .minutes(30))
+                context.sessions.setSession(.authenticated(user), expiresIn: .minutes(30))
             } catch {
                 context.logger.warning("Token refresh failed: \(error)")
                 // Let the request continue — downstream handlers can check
@@ -324,14 +324,10 @@ where Context.Session == UserSession {
 Wire it into a route group after `SessionMiddleware`:
 
 ```swift
-let env = try await Environment().merging(with: Environment.dotEnv(".env"))
-
-let protectedGroup = router.group()
+router.group()
     .add(middleware: TokenRefreshMiddleware(
         oauthKit: oauthKit,
-        clientID: try env.require("google_client_id"),
-        clientSecret: try env.require("google_client_secret"),
-        redirectURI: try env.require("google_redirect_uri")
+        providerConfig: reader.scoped(to: "google")
     ))
 ```
 

--- a/Sources/OAuthKit/OAuthKit.docc/RefreshTokenSupport.md
+++ b/Sources/OAuthKit/OAuthKit.docc/RefreshTokenSupport.md
@@ -56,13 +56,11 @@ These providers use the `OAuth2Client` and return only token response (no ID tok
 
 ### Special Cases
 
-| Provider | Current Method | Ideal Method | Notes |
-|----------|----------------|--------------|-------|
-| **Apple** | Custom implementation | `provider.refreshAccessToken(refreshToken:)` | Uses JWT-based authentication |
+| Provider | Notes |
+|----------|-------|
+| **Apple** | Uses JWT-based client authentication; refresh follows the same `provider.refreshAccessToken(refreshToken:)` API. |
 
-## Current Implementation Examples
-
-**Note**: These examples show the current inconsistent API. In an ideal world, all providers would have `refreshAccessToken()` directly on the provider.
+## Implementation Examples
 
 ### Google (OpenID Connect)
 
@@ -93,7 +91,7 @@ let provider = try await oauthFactory.microsoftProvider(
     clientID: "your-client-id",
     clientSecret: "your-client-secret",
     redirectURI: "your-redirect-uri",
-    tenantID: .common
+    tenantKind: .common
 )
 
 // Request tokens with offline access
@@ -109,7 +107,7 @@ let (newTokens, claims) = try await provider.refreshAccessToken(refreshToken: st
 ### Discord (OAuth2)
 
 ```swift
-let provider = try await oauthFactory.discordProvider(
+let provider = oauthFactory.discordProvider(
     clientID: "your-client-id",
     clientSecret: "your-client-secret",
     redirectURI: "your-redirect-uri"
@@ -122,7 +120,7 @@ let (newTokens, _) = try await provider.refreshAccessToken(refreshToken: storedR
 ### GitHub (OAuth2)
 
 ```swift
-let provider = try await oauthFactory.githubProvider(
+let provider = oauthFactory.githubProvider(
     clientID: "your-client-id",
     clientSecret: "your-client-secret",
     redirectURI: "your-redirect-uri"
@@ -138,121 +136,125 @@ let userProfile = try await provider.getUserProfile(accessToken: newTokens.acces
 
 ## Generic Refresh Implementation
 
-For applications that support multiple providers, you can create a generic refresh function that handles the current API inconsistency:
+For applications that support multiple providers, you can create a generic refresh function:
 
 ```swift
+// Convenience accessor — replace with your config/DI approach in production.
+private func env(_ key: String) -> String {
+    guard let v = ProcessInfo.processInfo.environment[key], !v.isEmpty else {
+        fatalError("Missing required environment variable: \(key)")
+    }
+    return v
+}
+
 func refreshTokenForProvider(
     _ providerName: String,
     refreshToken: String,
     oauthFactory: OAuthClientFactory
 ) async throws -> (tokenResponse: TokenResponse, claims: IDTokenClaims?) {
-    
     switch providerName.lowercased() {
-    // OpenID Connect Providers with custom refresh methods
     case "google":
         let provider = try await oauthFactory.googleProvider(
-            clientID: Environment.get("GOOGLE_CLIENT_ID")!,
-            clientSecret: Environment.get("GOOGLE_CLIENT_SECRET")!,
-            redirectURI: Environment.get("GOOGLE_REDIRECT_URI")!
+            clientID: env("GOOGLE_CLIENT_ID"),
+            clientSecret: env("GOOGLE_CLIENT_SECRET"),
+            redirectURI: env("GOOGLE_REDIRECT_URI")
         )
         return try await provider.refreshAccessToken(refreshToken: refreshToken)
-        
-    // OpenID Connect Providers using client.refreshToken
+
     case "microsoft":
         let provider = try await oauthFactory.microsoftProvider(
-            clientID: Environment.get("MICROSOFT_CLIENT_ID")!,
-            clientSecret: Environment.get("MICROSOFT_CLIENT_SECRET")!,
-            redirectURI: Environment.get("MICROSOFT_REDIRECT_URI")!,
-            tenantID: .common
+            clientID: env("MICROSOFT_CLIENT_ID"),
+            clientSecret: env("MICROSOFT_CLIENT_SECRET"),
+            redirectURI: env("MICROSOFT_REDIRECT_URI"),
+            tenantKind: .common
         )
         return try await provider.refreshAccessToken(refreshToken: refreshToken)
-        
+
     case "auth0":
         let provider = try await oauthFactory.auth0Provider(
-            clientID: Environment.get("AUTH0_CLIENT_ID")!,
-            clientSecret: Environment.get("AUTH0_CLIENT_SECRET")!,
-            domain: Environment.get("AUTH0_DOMAIN")!,
-            redirectURI: Environment.get("AUTH0_REDIRECT_URI")!
+            domain: env("AUTH0_DOMAIN"),
+            clientID: env("AUTH0_CLIENT_ID"),
+            clientSecret: env("AUTH0_CLIENT_SECRET"),
+            redirectURI: env("AUTH0_REDIRECT_URI")
         )
         return try await provider.refreshAccessToken(refreshToken: refreshToken)
-        
+
     case "okta":
         let provider = try await oauthFactory.oktaProvider(
-            clientID: Environment.get("OKTA_CLIENT_ID")!,
-            clientSecret: Environment.get("OKTA_CLIENT_SECRET")!,
-            domain: Environment.get("OKTA_DOMAIN")!,
-            redirectURI: Environment.get("OKTA_REDIRECT_URI")!
+            domain: env("OKTA_DOMAIN"),
+            clientID: env("OKTA_CLIENT_ID"),
+            clientSecret: env("OKTA_CLIENT_SECRET"),
+            redirectURI: env("OKTA_REDIRECT_URI")
         )
         return try await provider.refreshAccessToken(refreshToken: refreshToken)
-        
+
     case "cognito":
         let provider = try await oauthFactory.awsCognitoProvider(
-            clientID: Environment.get("COGNITO_CLIENT_ID")!,
-            clientSecret: Environment.get("COGNITO_CLIENT_SECRET")!,
-            region: Environment.get("COGNITO_REGION")!,
-            userPoolID: Environment.get("COGNITO_USER_POOL_ID")!,
-            redirectURI: Environment.get("COGNITO_REDIRECT_URI")!
+            region: env("COGNITO_REGION"),
+            userPoolID: env("COGNITO_USER_POOL_ID"),
+            clientID: env("COGNITO_CLIENT_ID"),
+            clientSecret: ProcessInfo.processInfo.environment["COGNITO_CLIENT_SECRET"],
+            redirectURI: env("COGNITO_REDIRECT_URI")
         )
         return try await provider.refreshAccessToken(refreshToken: refreshToken)
-        
-    // OAuth2 Providers
+
     case "discord":
-        let provider = try await oauthFactory.discordProvider(
-            clientID: Environment.get("DISCORD_CLIENT_ID")!,
-            clientSecret: Environment.get("DISCORD_CLIENT_SECRET")!,
-            redirectURI: Environment.get("DISCORD_REDIRECT_URI")!
+        let provider = oauthFactory.discordProvider(
+            clientID: env("DISCORD_CLIENT_ID"),
+            clientSecret: env("DISCORD_CLIENT_SECRET"),
+            redirectURI: env("DISCORD_REDIRECT_URI")
         )
         return try await provider.refreshAccessToken(refreshToken: refreshToken)
-        
+
     case "github":
-        let provider = try await oauthFactory.githubProvider(
-            clientID: Environment.get("GITHUB_CLIENT_ID")!,
-            clientSecret: Environment.get("GITHUB_CLIENT_SECRET")!,
-            redirectURI: Environment.get("GITHUB_REDIRECT_URI")!
+        let provider = oauthFactory.githubProvider(
+            clientID: env("GITHUB_CLIENT_ID"),
+            clientSecret: env("GITHUB_CLIENT_SECRET"),
+            redirectURI: env("GITHUB_REDIRECT_URI")
         )
         return try await provider.refreshAccessToken(refreshToken: refreshToken)
-        
+
     case "facebook":
         let provider = try await oauthFactory.facebookProvider(
-            clientID: Environment.get("FACEBOOK_CLIENT_ID")!,
-            clientSecret: Environment.get("FACEBOOK_CLIENT_SECRET")!,
-            redirectURI: Environment.get("FACEBOOK_REDIRECT_URI")!
+            appID: env("FACEBOOK_CLIENT_ID"),
+            appSecret: env("FACEBOOK_CLIENT_SECRET"),
+            redirectURI: env("FACEBOOK_REDIRECT_URI")
         )
         return try await provider.refreshAccessToken(refreshToken: refreshToken)
-        
+
     case "linkedin":
-        let provider = try await oauthFactory.linkedInProvider(
-            clientID: Environment.get("LINKEDIN_CLIENT_ID")!,
-            clientSecret: Environment.get("LINKEDIN_CLIENT_SECRET")!,
-            redirectURI: Environment.get("LINKEDIN_REDIRECT_URI")!
+        let provider = try await oauthFactory.linkedinProvider(
+            clientID: env("LINKEDIN_CLIENT_ID"),
+            clientSecret: env("LINKEDIN_CLIENT_SECRET"),
+            redirectURI: env("LINKEDIN_REDIRECT_URI")
         )
         return try await provider.refreshAccessToken(refreshToken: refreshToken)
-        
+
     case "gitlab":
         let provider = try await oauthFactory.gitlabProvider(
-            clientID: Environment.get("GITLAB_CLIENT_ID")!,
-            clientSecret: Environment.get("GITLAB_CLIENT_SECRET")!,
-            redirectURI: Environment.get("GITLAB_REDIRECT_URI")!,
+            clientID: env("GITLAB_CLIENT_ID"),
+            clientSecret: env("GITLAB_CLIENT_SECRET"),
+            redirectURI: env("GITLAB_REDIRECT_URI"),
             customInstance: nil
         )
         return try await provider.refreshAccessToken(refreshToken: refreshToken)
-        
+
     case "dropbox":
-        let provider = try await oauthFactory.dropboxProvider(
-            clientID: Environment.get("DROPBOX_CLIENT_ID")!,
-            clientSecret: Environment.get("DROPBOX_CLIENT_SECRET")!,
-            redirectURI: Environment.get("DROPBOX_REDIRECT_URI")!
+        let provider = oauthFactory.dropboxProvider(
+            clientID: env("DROPBOX_CLIENT_ID"),
+            clientSecret: env("DROPBOX_CLIENT_SECRET"),
+            redirectURI: env("DROPBOX_REDIRECT_URI")
         )
         return try await provider.refreshAccessToken(refreshToken: refreshToken)
-        
+
     case "slack":
-        let provider = try await oauthFactory.slackProvider(
-            clientID: Environment.get("SLACK_CLIENT_ID")!,
-            clientSecret: Environment.get("SLACK_CLIENT_SECRET")!,
-            redirectURI: Environment.get("SLACK_REDIRECT_URI")!
+        let provider = oauthFactory.slackProvider(
+            clientID: env("SLACK_CLIENT_ID"),
+            clientSecret: env("SLACK_CLIENT_SECRET"),
+            redirectURI: env("SLACK_REDIRECT_URI")
         )
         return try await provider.refreshAccessToken(refreshToken: refreshToken)
-        
+
     default:
         throw OAuth2Error.configurationError("Unsupported provider for token refresh: \(providerName)")
     }
@@ -261,55 +263,79 @@ func refreshTokenForProvider(
 
 ## Automatic Token Refresh
 
-Here's a middleware example that automatically refreshes tokens when needed:
+Here's a Hummingbird 2 middleware that automatically refreshes tokens before they expire.
+See <doc:HummingbirdIntegration> for the full session and context setup.
 
 ```swift
-struct TokenRefreshMiddleware: AsyncMiddleware {
-    let oauthFactory: OAuthClientFactory
-    
-    func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
-        // Check if token needs refresh
-        guard let refreshToken = request.session.data["refresh_token"],
-              let expiresAt = request.session.data["token_expires_at"],
-              let provider = request.session.data["provider"],
-              let expiryTime = Double(expiresAt) else {
-            return try await next.respond(to: request)
-        }
-        
-        // Refresh if token expires within 5 minutes
-        let now = Date().timeIntervalSince1970
-        if now >= expiryTime - 300 {
+import Hummingbird
+import HummingbirdAuth
+import OAuthKit
+
+/// Refreshes an expired Google access token before the request reaches
+/// downstream route handlers.
+///
+/// Inject credentials via the initializer — `Environment` can't be awaited
+/// inside `handle`, so resolve configuration at application startup instead.
+struct TokenRefreshMiddleware<Context: SessionRequestContext>: RouterMiddleware
+where Context.Session == UserSession {
+
+    let oauthKit: OAuthClientFactory
+    let clientID: String
+    let clientSecret: String
+    let redirectURI: String
+
+    func handle(
+        _ request: Request,
+        context: Context,
+        next: (Request, Context) async throws -> Response
+    ) async throws -> Response {
+        if var session = context.sessions.session,
+           let refreshToken = session.refreshToken {
             do {
-                let (newTokens, _) = try await refreshTokenForProvider(
-                    provider,
-                    refreshToken: refreshToken,
-                    oauthFactory: oauthFactory
+                let provider = try await oauthKit.googleProvider(
+                    clientID: clientID,
+                    clientSecret: clientSecret,
+                    redirectURI: redirectURI
                 )
-                
-                // Update session with new tokens
-                request.session.data["access_token"] = newTokens.accessToken
-                if let newRefreshToken = newTokens.refreshToken {
-                    request.session.data["refresh_token"] = newRefreshToken
-                }
-                if let expiresIn = newTokens.expiresIn {
-                    request.session.data["token_expires_at"] = String(now + Double(expiresIn))
-                }
-                
+                let newTokens = try await provider.refreshAccessToken(
+                    refreshToken: refreshToken
+                )
+                session = UserSession(
+                    id: session.id,
+                    name: session.name,
+                    email: session.email,
+                    accessToken: newTokens.accessToken,
+                    refreshToken: newTokens.refreshToken ?? session.refreshToken,
+                    idToken: newTokens.idToken ?? session.idToken,
+                    provider: session.provider
+                )
+                context.sessions.setSession(session, expiresIn: .minutes(30))
             } catch {
-                // Log error and potentially redirect to re-authentication
-                request.logger.error("Token refresh failed: \(error)")
-                throw Abort(.unauthorized, reason: "Token refresh failed")
+                context.logger.warning("Token refresh failed: \(error)")
+                // Let the request continue — downstream handlers can check
+                // whether the access token is still usable.
             }
         }
-        
-        return try await next.respond(to: request)
+        return try await next(request, context)
     }
 }
 ```
 
-## API Standardization Proposal
+Wire it into a route group after `SessionMiddleware`:
 
-To improve developerBest Practices
+```swift
+let env = try await Environment().merging(with: Environment.dotEnv(".env"))
+
+let protectedGroup = router.group()
+    .add(middleware: TokenRefreshMiddleware(
+        oauthKit: oauthKit,
+        clientID: try env.require("google_client_id"),
+        clientSecret: try env.require("google_client_secret"),
+        redirectURI: try env.require("google_redirect_uri")
+    ))
+```
+
+## Best Practices
 
 ### 1. Secure Storage
 Always store refresh tokens securely:

--- a/Sources/OAuthKit/Providers/MicrosoftOAuthProvider.swift
+++ b/Sources/OAuthKit/Providers/MicrosoftOAuthProvider.swift
@@ -157,6 +157,31 @@ public struct MicrosoftOAuthProvider: Sendable {
         return userInfo
     }
 
+    /// Build the end-session (logout) URL for Microsoft sign-out.
+    ///
+    /// Redirects the user to the Microsoft identity platform's end-session endpoint so
+    /// the provider also invalidates the session on its side (SSO logout). The provider
+    /// must have advertised `end_session_endpoint` in its OIDC discovery document
+    /// (Microsoft always does).
+    ///
+    /// - Parameters:
+    ///   - idToken: The raw ID token from the user's session (`UserSession.idToken`).
+    ///   - postLogoutRedirectURI: URI to redirect back to after Microsoft logs the user out.
+    ///   - state: Optional opaque state carried through to `postLogoutRedirectURI`.
+    /// - Returns: The fully-qualified end-session URL.
+    /// - Throws: `OAuth2Error.configurationError` if the provider has no end-session endpoint.
+    public func endSessionURL(
+        idToken: String,
+        postLogoutRedirectURI: String? = nil,
+        state: String? = nil
+    ) throws -> URL {
+        try client.endSessionURL(
+            idToken: idToken,
+            postLogoutRedirectURI: postLogoutRedirectURI,
+            state: state
+        )
+    }
+
     /// Call the Microsoft Graph API
     /// - Parameters:
     ///   - accessToken: The access token from the token response


### PR DESCRIPTION
Major docs and API updates across OAuthKit examples and providers.

- HummingbirdIntegration.md: Reworked for Hummingbird 2 and HummingbirdAuth — introduces a typed UserSession, OAuthHandshake, pendingHandshakes store, and new helpers (makeAuthURL, exchangeCode, makeEndSessionURL). Updates routing, session usage, token refresh middleware, error mapping, and security best practices.
- DeviceFlowExample.md & OktaMFA.md: Fix parameter ordering/usage (e.g. auth0 domain placement) and rename tenantID -> tenantKind where applicable.
- OpenIDConnect.md: Use OAuthClientFactory.openIDConnectClient, adjust PKCE usage and token/nonce handling, and update OAuth2Error case names.
- RefreshTokenSupport.md: Add env helper, standardize provider refresh calls, switch to tenantKind for Microsoft, and provide a Hummingbird 2 TokenRefreshMiddleware example and integration guidance.
- MicrosoftOAuthProvider.swift: Add endSessionURL wrapper to build provider logout (OIDC end_session_endpoint) URLs.

These changes update examples to current APIs, improve Hummingbird integration guidance, and standardize refresh/logout flows.

cc @adam-fowler